### PR TITLE
Test cross compilation in test.sh

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -28,6 +28,9 @@ jobs:
       # the build times separately from the test times.
       - run: go build ./...
       - run: go build -race ./...
+      # NOTE: test.sh cross compiles for Linux here, but skips its macOS builds
+      # since those need the macOS SDK for CGO. Those are only covered by
+      # running test.sh on a Mac, which release.sh does before every release.
       - run: ./test.sh
 
       # -race is not supported on i386

--- a/release.sh
+++ b/release.sh
@@ -84,6 +84,8 @@ echo "Building ${VERSION} release binaries..."
 
 # NOTE: To get the version number right, production builds must be done after
 # the above tagging.
+#
+# NOTE: Keep this list in sync with the cross compilation test in test.sh
 GOOS=linux GOARCH=386 ./build.sh
 GOOS=linux GOARCH=arm ./build.sh
 

--- a/test.sh
+++ b/test.sh
@@ -24,5 +24,26 @@ if [ "$(go env GOARCH)" == "386" ]; then
 fi
 go test $RACE -timeout 20s ./...
 
+# Ensure we can build for all platforms we release for
+#
+# NOTE: Keep this list in sync with the release builds in release.sh
+echo
+echo "Testing cross compilation..."
+echo "  Linux i386..."
+GOOS=linux GOARCH=386 ./build.sh
+echo "  Linux arm32..."
+GOOS=linux GOARCH=arm ./build.sh
+
+# The macOS binaries get their system stats through CGO, and cross compiling
+# CGO code for macOS requires the macOS SDK. So these builds only work on macOS.
+if [ "$(go env GOHOSTOS)" = "darwin" ]; then
+  echo "  macOS amd64..."
+  CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 ./build.sh
+  echo "  macOS arm64..."
+  CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 ./build.sh
+else
+  echo "  Skipping the macOS builds, they need the macOS SDK for CGO"
+fi
+
 echo
 echo "All tests passed!"


### PR DESCRIPTION
AGENTS.md claimed `./test.sh` does cross compiling. It did not, so now it does, covering exactly the platforms `release.sh` ships: Linux i386 and arm32, macOS amd64 and arm64.

The macOS builds get their system stats through CGO (`internal/sysload/sysload_darwin.go`), and cross compiling that needs the macOS SDK, so they are skipped when the host is not a Mac. Verified locally on macOS: all four targets build, and `shellcheck` is clean on both scripts.

Consequence worth knowing: this CI job only ever validates the Linux builds. The macOS ones are covered by running `./test.sh` on a Mac, which `release.sh` does before every release. Adding a macOS CI job would close that gap, but that is out of scope here.

Also made `release.sh` and `test.sh` point at each other, so the two platform lists stay in sync.

🤖 Written by Claude (Opus 5)