### PR TITLE
johan/pipes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,63 @@
 Use `./test.sh` to run all tests. In addition to just running all tests, that
 script will do linting, some cross compiling and more.
 
+# Running The Tests On Linux
+
+**Not part of the routine.** `./test.sh` on a Mac is what a change has to pass,
+and CI on `main` covers Linux — most changes can't break it specifically, so
+don't reach for a container by default.
+
+It earns its few minutes when a change reads output that differs per platform,
+`lsof` and `ps` above all, or when a Linux-only path is the thing being changed.
+`./test.sh` on a Mac builds the Linux binaries but runs none of them, so those
+are the cases where passing locally says the least. A container runs the real
+thing:
+
+```bash
+docker run --rm -it -v "$PWD:/src" -v ftop-gomod:/go/pkg/mod \
+  -v ftop-gobuild:/root/.cache/go-build -w /src golang:1.25 bash
+```
+
+Then, inside:
+
+```bash
+apt-get update && apt-get install -y lsof procps wtmpdb
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+  | sh -s -- -b "$(go env GOPATH)"/bin v2.8.0
+wtmpdb boot
+./test.sh
+```
+
+Every line of that is load bearing, so adapt rather than drop: the image has
+neither `lsof` nor the `ps` ftop forks, `test.sh` insists on the golangci-lint
+version `.github/workflows/linux-ci.yml` installs, and `wtmpdb boot` gives `last`
+a database, without which `TestGetUsersAtSmoke` fails. On Debian 13 `last` comes
+from `wtmpdb` and not from `util-linux`.
+
+Run `test.sh` from the `docker run` shell rather than through a later
+`docker exec`: an exec'd process has no parent inside the container's PID
+namespace, so `TestGetAll`'s walk up to init lands on the shell instead of on PID
+1. The two cache volumes are what makes a second run cost seconds. Add
+`--privileged` if the test needs to mount anything.
+
+Driving the terminal UI in there needs a pty with a real window size, which
+`docker exec` does not give it: wrap it as
+`script -qec "stty rows 60 cols 170; ./ftop" /dev/null` and feed keystrokes on
+stdin with `sleep`s between them.
+
 # Manual Testing
 
 If the user wants to test manually, ask them to run `./ftop.sh` rather than
 building a binary yourself. `ftop.sh` builds and runs the current sources with
 race detection enabled.
+
+# Test Conventions
+
+Tests that parse a subprocess' output use inline fixture strings, per
+`cwds_test.go`. This repo has no `testdata/` directory and shouldn't grow one.
+
+Assert a page section against a whole expected block, via `sectionBody()`, rather
+than picking fragments out of it. Alignment is a feature of those sections.
 
 # Fixing Bugs
 

--- a/IPC-DESIGN.md
+++ b/IPC-DESIGN.md
@@ -73,12 +73,11 @@ That first measurement is about the `d` field and does not carry over to the
 `PipeConnections()` does with any pipe it can find no peer for.
 
 The two *device* fields are different things, and neither is what the disjointness
-rests on. Lowercase `d` is empty for every `FIFO` record on both platforms — that
-is what the earlier "0 of 20 `FIFO` records carry a device" measurement really
-established — while uppercase `D` is a file system device Linux reports for every
-pipe, anonymous ones living on pipefs and sharing `0xe`. macOS reports no `D` for
-a pipe of either kind, so there two pipes are told apart by their inodes and
-kernel addresses alone.
+rests on. Lowercase `d` is empty for every `FIFO` record on both platforms, while
+uppercase `D` is a file system device Linux reports for every pipe, anonymous ones
+living on pipefs and sharing `0xe`. macOS reports no `D` for a pipe of either
+kind, so there two pipes are told apart by their inodes and kernel addresses
+alone.
 
 **Do not copy px's four index maps** (`px_ipc_map.py:191-220`). They exist to
 make `_get_other_end_pids()` O(1) per file because Python makes the scan
@@ -130,20 +129,19 @@ Measured on a macOS laptop, non-root:
 | --- | --- | --- |
 | `lsof -n -P -F fnaptd0iP` (full, px-style) | 0.27 s | 1.24 MB |
 | `lsof -n -P -i -F fnaptd0iP` | 0.13 s | 33 KB |
-| `lsof -n -P -w -iTCP -F pfnT0` (the TCP slice's, since superseded) | 0.13 s | — |
 | `lsof -n -w -d cwd -F pfn0` (already in the tree) | 0.22 s | 15 KB |
 
 This is a **second lsof fork**, separate from the cwd one in `cwds.go`, and pipes
 have since added a third. Sharing one is still rejected; the cost argument is in
 `GetSocketsByPid()` and the independent-degradation one on `socketListing`, while
-"Deferred" carries the current terms, which the pipe fork changed.
+"Deferred" carries the current terms.
 
-Two measurements behind the flags `sockets.go` documents. **A plain `-i`**, which
-is a reversal: the narrower `-iTCP -iUDP` came first, for excluding the `PICMP`
-and `PICMPV6` records macOS adds under a bare `-i`, and it cost more than it
-bought. Each `-i` is a *search item*, and lsof exits 1 for every item that located
-nothing however well the others did, so the pair failed on any machine holding no
-socket of one kind — a container with an empty `/proc/net/tcp` failed it always.
+Two measurements behind the flags `sockets.go` documents. **Why a plain `-i` and
+not `-iTCP -iUDP`**, which is the narrower spelling and would keep out the `PICMP`
+and `PICMPV6` records macOS adds under a bare `-i`: the pair costs more than it
+buys. Each `-i` is a *search item*, and lsof exits 1 for every item that located
+nothing however well the others did, so the pair fails on any machine holding no
+socket of one kind — a container with an empty `/proc/net/tcp` fails it always.
 With one UDP socket up and no TCP, lsof 4.99.4 prints the socket and still exits
 1, which `-V` spells out:
 
@@ -154,8 +152,8 @@ lsof: Internet address not located: TCP
 
 One item makes a non-zero exit mean "no internet sockets at all", and the ICMP
 records get dropped in `parseLine()` instead. An fd selection like `-d cwd` is not
-a search item and never exited this way, which is why `cwds.go` and the pipe fork
-never saw it. **`-Ts` does not narrow the state field down**, also verified — the
+a search item and never exits this way, which is why `cwds.go` and the pipe fork
+never see it. **`-Ts` does not narrow the state field down**, also verified — the
 queue sizes come along regardless, which is why the parser dispatches on the `ST=`
 value prefix.
 
@@ -233,8 +231,8 @@ process being invisible from there.
 **The pipe display, exercised by hand** *(run 4)*. The container recipe has moved
 to `AGENTS.md`, being useful for verifying anything on Linux rather than pipes in
 particular; `--privileged` is what allows the two `mount` calls below. Three shells
-holding FIFO ends plus one real pipeline, which is the shape the two matching fixes
-are about:
+holding FIFO ends plus one real pipeline, which is the shape that tells the inode
+clause in `arePipeEnds()` apart from a bare inode comparison:
 
 ```
 mkdir -p /mnt/a /mnt/b
@@ -253,26 +251,16 @@ tail -f /etc/services | sort | nl &                         # a real pipeline
 that numbers from scratch. Open the shells' pages and the two holding an end of
 each FIFO report one another as `pipe (×2)`; the `w`-and-`u` shell draws one line
 per peer, `<?>` because its own two ends let it both write the pipe and read it,
-plus a line to itself for the FIFO it can write on fd 3 and read back on fd 4. On
-the inode alone those pages read `pipe` with no count and five lines instead of
-three, two of them arrows the `u` end contradicts, which is what the two fixes
-close.
+plus a line to itself for the FIFO it can write on fd 3 and read back on fd 4.
+Matching on the inode alone makes those same pages read `pipe` with no count and
+five lines instead of three, two of them arrows the `u` end contradicts — which is
+what the file system device check and the read-pairs-with-write test in the inode
+clause are each keeping out.
 
 The pipeline gets its arrows, `tail(7612) --> sort(7613)` and
 `sort(7613) --> nl(7614)`, Linux reporting the access modes macOS won't — the same
 pipeline that reads `<?>` on a laptop, see "Deferred" on taking that direction from
 the kernel instead.
-
-**Both socket sections degraded on their own** *(run 4)*, which is the independence
-the two-listing decision was for, observed for the only time so far. A container
-with no TCP socket made `lsof -iTCP -iUDP` exit 1, so the socket listing failed
-outright while the unfiltered pipe listing succeeded: the IPC section rendered
-`<Unable to list sockets: ...>` and then its pipe lines below it, and Network
-Connections rendered the error alone.
-
-That trigger is gone — an empty machine is no longer a failed listing, see "Data
-collection" — and it was the only one anybody had found, so the independence is
-back to being designed-for rather than demonstrated.
 
 Still unverified: behaviour on a busy multi-user box, which is the environment
 this is ultimately for. Run 2 loaded the container up with sockets and open
@@ -404,9 +392,8 @@ that live nowhere else:
   Merging means one call with the union of the fields and three parsers over it,
   and it trades away what "Data collection" above wants kept: `-i` scales with
   socket count where the unfiltered listing scales with every fd on the machine,
-  and the sections stop degrading independently — which run 4 observed them doing,
-  though nothing triggers that any more. So this is a measurement to make on a
-  busy box, not a cleanup to do.
+  and the sections stop degrading independently. So this is a measurement to make
+  on a busy box, not a cleanup to do.
 - **Re-sorting remote peers by resolved name.** Rows sort on `Peer.Name`, which
   for a remote host is its address, and then render as a host name — so with
   several remote peers the visible order isn't alphabetical by what the reader

--- a/IPC-DESIGN.md
+++ b/IPC-DESIGN.md
@@ -35,23 +35,30 @@ added: a `Protocol` field, `DirectionUnknown` rendered `<?>`, and the protocol a
 part of the keys identifying a connection. Bound but unconnected UDP sockets are
 dropped, see "Deferred" below.
 
-**Pipes: not started.** See "The remaining two kinds".
+**Pipes: done.** `GetPipeEndsByPid()` plus `PipeConnections()` in
+`internal/processes`, rendered into the IPC section beside the sockets. A second,
+unfiltered lsof fork, and two matching mechanisms in one predicate — see "Pipes"
+below, and "Verified on Linux" run 4 for what the page looks like. Anonymous pipes
+are `<?>` on macOS, lsof reporting no access mode there; see "Deferred".
 
 **Unix domain sockets: not started.** Hardest of the three, and for a reason no
-amount of code solves. See "The remaining two kinds".
+amount of code solves. See "Pipes and unix domain sockets".
 
-## The remaining two kinds
+## Pipes and unix domain sockets
 
 There are four kinds of IPC lsof can report: pipes (`PIPE` on macOS, `FIFO` on
 Linux), unix domain sockets (`unix`), and network sockets (`IPv4`/`IPv6`) — where
 "local" vs "remote" is not a separate detection path, just whether a peer was
 found. Network sockets came first because their peer matching is byte-identical
-on Linux and macOS.
+on Linux and macOS. Unix domain sockets are the one kind still missing; what
+follows is how pipes work, and then the plan for those.
 
-Both remaining kinds need lsof **without** an `-i` filter, since there is no
-filter flag for pipes. That is the 0.27 s / 1.24 MB invocation in the table
-below, against 0.13 s / 33 KB for the socket one, and it is a third fork unless
-the sections start sharing.
+Pipes needed lsof **without** an `-i` filter, there being no filter flag for
+pipes: the 0.27 s / 1.24 MB invocation in the table below, against 0.13 s / 33 KB
+for the socket one, and a third fork unless the sections start sharing. Unix
+domain sockets will not force that on us again — `-U` selects them — though they
+could ride the pipe listing rather than fork a fourth time. See "Deferred" for
+what sharing one fork would cost.
 
 ### Pipes
 
@@ -117,7 +124,7 @@ port without changes.
 
 ### Unix domain sockets
 
-macOS is nearly free once pipes are done — same `d0x...` device against
+macOS is nearly free now that pipes are done — same `d0x...` device against
 `n->0x...` peer scheme, plus a path for listeners.
 
 **Linux is a data problem, not a code problem.** lsof emits nothing to join a
@@ -412,7 +419,8 @@ no `testdata/` directory and shouldn't grow one for this.
 
 ## Deferred, deliberately
 
-- **Pipes** and **unix domain sockets**, both scoped above.
+- **Unix domain sockets**, scoped above. The last of the four kinds, and the only
+  thing keeping this document alive.
 - **Bound but unconnected UDP sockets get no line.** They are dropped along with
   the bound TCP sockets that never carried anything. UDP has no listening state,
   so lsof gives us no way to tell a server's bound socket from the ephemeral
@@ -441,8 +449,16 @@ no `testdata/` directory and shouldn't grow one for this.
 - `(ssh)` service-name annotations next to port numbers. Cosmetic, needs
   `/etc/services` parsing, no model change.
 - A line cap for processes with hundreds of *distinct* peers.
-- Sharing one lsof invocation across sections, once there are three of them —
-  which the pipe work forces the question on, since pipes need an unfiltered lsof.
+- **Sharing one lsof invocation across sections.** There are three forks now, and
+  the pipe one already subsumes the other two: `lsof -n -w -F pfatdDin0` lists
+  every open file of every process, so the cwd listing in `cwds.go` and the
+  `-iTCP -iUDP` one in `sockets.go` both ask for subsets of it with different `-F`
+  fields. Merging means one call with the union of the fields and three parsers
+  over it, and it trades away what "Data collection" above wants kept: `-i` scales
+  with socket count where the unfiltered listing scales with every fd on the
+  machine, and the sections stop degrading independently — which run 4 observed
+  them doing, the socket listing failing outright while pipes rendered. So this is
+  a measurement to make on a busy box, not a cleanup to do.
 - **Re-sorting remote peers by resolved name.** Rows sort on `Peer.Name`, which
   for a remote host is its address, and then render as a host name — so with
   several remote peers the visible order isn't alphabetical by what the reader
@@ -453,10 +469,6 @@ no `testdata/` directory and shouldn't grow one for this.
   reverse resolving a TEST-NET address for real — puts a network call and up to
   2 s into the test suite. The function's fallback behaviour is covered at page
   level instead, via an address the fake resolver has no answer for.
-- **A protocol sort key.** Not needed while TCP is the only protocol reaching the
-  listening/incoming/outgoing groups and UDP the only one reaching the
-  undetermined group, which makes the blocks protocol-pure for free. Pipes and
-  unix sockets will break that assumption; revisit then.
 - **A test for the `listening` half of the socket identity.**
   `deduplicateBySocket()` keys on (protocol, local, remote, listening), and
   replacing that last field with a constant passes the whole suite — verified by

--- a/IPC-DESIGN.md
+++ b/IPC-DESIGN.md
@@ -70,21 +70,27 @@ each of two fresh tmpfs mounts is inode 2 on both. macOS matches on **our peer's
 kernel address against their device**: `theirs.Device ==
 strings.TrimPrefix(ours.Name, "->")`.
 
-**These need no `GOOS` switch.** What makes the two clauses disjoint is
-`PeerDevice`, which is populated from an `n->0x...` name and from nothing else:
-measured on a quiet macOS laptop, 358 of 358 `PIPE` records carry such a name and
-none carries an inode, while in a Debian container all 20 `FIFO` records carry an
-inode and not one is named that way — Linux spells an anonymous pipe `npipe` and a
-named FIFO by its path. So neither platform can satisfy the other's condition, and
-one predicate that ORs the two clauses is correct everywhere.
+**These need no `GOOS` switch.** Each clause tests a condition the other platform
+cannot meet. Measured on a quiet macOS laptop, 358 of 358 `PIPE` records carry a
+lowercase `d` device and **none carries an inode**, so no macOS anonymous pipe
+reaches the inode clause; in a Debian container all 20 `FIFO` records carry an
+inode and **not one is named `->...`**, Linux spelling an anonymous pipe `npipe`
+and a named FIFO by its path, so no Linux pipe reaches the device clause. One
+predicate that ORs the two clauses is therefore correct everywhere.
 
-Note that a *device* being present says nothing about which clause applies, the
-two fields being different things. Lowercase `d` is empty for every `FIFO` record
-on both platforms — that is what the earlier "0 of 20 `FIFO` records carry a
-device" measurement really established — while uppercase `D` is a file system
-device that Linux reports for every pipe, anonymous ones living on pipefs and
-sharing `0xe`. macOS reports no `D` for a pipe of either kind, so there two pipes
-are told apart by their inodes and kernel addresses alone.
+That first measurement is about the `d` field and does not carry over to the
+`->...` name, which is the narrower of the two. Measured on the same laptop later:
+311 of 311 `PIPE` records carry a `d`, but only 303 are named `->...` — the other
+8 are pipes whose peer is gone. Those match nothing and get no line, which is what
+`PipeConnections()` does with any pipe it can find no peer for.
+
+The two *device* fields are different things, and neither is what the disjointness
+rests on. Lowercase `d` is empty for every `FIFO` record on both platforms — that
+is what the earlier "0 of 20 `FIFO` records carry a device" measurement really
+established — while uppercase `D` is a file system device Linux reports for every
+pipe, anonymous ones living on pipefs and sharing `0xe`. macOS reports no `D` for
+a pipe of either kind, so there two pipes are told apart by their inodes and
+kernel addresses alone.
 
 **Do not copy px's four index maps** (`px_ipc_map.py:191-220`). They exist to
 make `_get_other_end_pids()` O(1) per file because Python makes the scan

--- a/IPC-DESIGN.md
+++ b/IPC-DESIGN.md
@@ -132,9 +132,9 @@ Measured on a macOS laptop, non-root:
 | `lsof -n -w -d cwd -F pfn0` (already in the tree) | 0.22 s | 15 KB |
 
 This is a **second lsof fork**, separate from the cwd one in `cwds.go`, and pipes
-have since added a third. Sharing one is still rejected; the cost argument is in
-`GetSocketsByPid()` and the independent-degradation one on `socketListing`, while
-"Deferred" carries the current terms.
+have since added a third. Sharing one is still rejected on the terms the
+"Deferred" bullet on sharing carries: what `-i` costs against an unfiltered
+listing, and the sections' independent degradation.
 
 Two measurements behind the flags `sockets.go` documents. **Why a plain `-i` and
 not `-iTCP -iUDP`**, which is the narrower spelling and would keep out the `PICMP`

--- a/IPC-DESIGN.md
+++ b/IPC-DESIGN.md
@@ -9,10 +9,11 @@ it doesn't get relitigated.
 door at `../px`.
 
 **Lifecycle:** this outlives the implemented slices, because the deferred work at
-the bottom depends on it. **Decided: it goes to `main` and stays there** until
-pipes and unix domain sockets are both implemented, at which point it dies — and
-before deleting it, salvage the "Verified on Linux" findings and the
-rejected-alternative rationale into comments next to the code they explain.
+the bottom depends on it. **Decided: it goes to `main` and stays there** until unix
+domain sockets are implemented, at which point it dies — and before deleting it,
+salvage the "Verified on Linux" findings and the rejected-alternative rationale
+into comments next to the code they explain. Each slice that lands should be
+taking its own share of that with it, leaving less to salvage at the end.
 
 Rationale that has already been salvaged is **not repeated here**. The direction
 rule and its known limits live in `directionAndPort()`, the deduplication
@@ -24,22 +25,13 @@ alternatives, verification findings, and the plan for what isn't built yet.
 
 ## Status
 
-**TCP: done.** `GetSocketsByPid()` plus `NetworkConnections()` in
-`internal/processes`, rendered by `pageipcconnections.go` and
-`pagenetworkconnections.go` over the shared layout in `pageconnections.go`.
-
-**UDP: done.** Same lsof call, same parser, same reversed-pair peer matching —
-lsof names a UDP socket in exactly the format it names a TCP one in, so nothing
-new was needed for matching and there is no platform specific code. What UDP
-added: a `Protocol` field, `DirectionUnknown` rendered `<?>`, and the protocol as
-part of the keys identifying a connection. Bound but unconnected UDP sockets are
-dropped, see "Deferred" below.
-
-**Pipes: done.** `GetPipeEndsByPid()` plus `PipeConnections()` in
-`internal/processes`, rendered into the IPC section beside the sockets. A second,
-unfiltered lsof fork, and two matching mechanisms in one predicate — see "Pipes"
-below, and "Verified on Linux" run 4 for what the page looks like. Anonymous pipes
-are `<?>` on macOS, lsof reporting no access mode there; see "Deferred".
+**TCP, UDP and pipes: done.** `GetSocketsByPid()` and `GetPipeEndsByPid()` collect,
+`NetworkConnections()` and `PipeConnections()` aggregate, all in
+`internal/processes`; `pageipcconnections.go` and `pagenetworkconnections.go`
+render over the shared layout in `pageconnections.go`. What each kind added is in
+git rather than here. Two behaviours to know before reading a page and concluding
+it is broken: a bound but unconnected UDP socket gets no line, and an anonymous
+pipe on macOS gets no arrow. Both are under "Deferred".
 
 **Unix domain sockets: not started.** Hardest of the three, and for a reason no
 amount of code solves. See "Pipes and unix domain sockets".
@@ -62,28 +54,17 @@ what sharing one fork would cost.
 
 ### Pipes
 
-Two mechanisms, verified against real pipe pairs on both platforms:
+Both matching mechanisms, and the reason one predicate can OR them with no `GOOS`
+switch, are documented at `arePipeEnds()`; the lsof records they read are in
+`lsofPipeParser`'s doc comment. What no code comment carries is the evidence for
+that reason, and the px alternative that was rejected.
 
-```
-Linux   tFIFO  D0xe  i16466  npipe            ar / aw
-macOS   tPIPE  d0x48d4efd2cbb7a037  n->0x7249c1bc766ed78e
-```
-
-Linux matches on **file system device plus inode plus opposing `r`/`w` access**;
-the name is the literal string `pipe` and identifies nothing, which px says
-outright at `px_file.py:85-88`. The device is the uppercase `D` field, and it is
-needed because an inode number is only unique within one file system: a FIFO on
-each of two fresh tmpfs mounts is inode 2 on both. macOS matches on **our peer's
-kernel address against their device**: `theirs.Device ==
-strings.TrimPrefix(ours.Name, "->")`.
-
-**These need no `GOOS` switch.** Each clause tests a condition the other platform
-cannot meet. Measured on a quiet macOS laptop, 358 of 358 `PIPE` records carry a
-lowercase `d` device and **none carries an inode**, so no macOS anonymous pipe
-reaches the inode clause; in a Debian container all 20 `FIFO` records carry an
+**Why the two clauses cannot both fire.** Each tests a condition the other
+platform cannot meet. Measured on a quiet macOS laptop, 358 of 358 `PIPE` records
+carry a lowercase `d` device and **none carries an inode**, so no macOS anonymous
+pipe reaches the inode clause; in a Debian container all 20 `FIFO` records carry an
 inode and **not one is named `->...`**, Linux spelling an anonymous pipe `npipe`
-and a named FIFO by its path, so no Linux pipe reaches the device clause. One
-predicate that ORs the two clauses is therefore correct everywhere.
+and a named FIFO by its path, so no Linux pipe reaches the device clause.
 
 That first measurement is about the `d` field and does not carry over to the
 `->...` name, which is the narrower of the two. Measured on the same laptop later:
@@ -104,23 +85,8 @@ make `_get_other_end_pids()` O(1) per file because Python makes the scan
 expensive; matching ~20 of our own fds against a few thousand pipe files is
 microseconds in Go. The indexes are also what *forces* px's platform switch: a
 map key has to be one string, so `fifo_id()` must choose inode-or-name up front,
-while a predicate can just test both.
-
-**Display grammar: reuse `writeConnectionLines()` as it stands.** One line per
-pipe, so a process in the middle of a pipeline gets one line per end — the same
-shape as every other kind.
-
-Data flows from the writer to the reader, which is a direction worth an arrow and
-which maps onto the existing split — write end outgoing, read end incoming, so
-`grep(1234) --> sort(5678)` from either end's page. Linux has the access mode
-already, since matching needs `a` anyway; wherever it turns out not to be
-available, fall back to `DirectionUnknown` and `<?>` — see "Deferred" for where
-macOS keeps the access mode when lsof won't hand it over.
-
-Pipes have no port, and `connectionDescription()` appends one unconditionally.
-So it needs a no-port case, rendering the bare protocol: `pipe`, and `pipe (×3)`
-where several to the same peer aggregate — the aggregation key tolerates a zero
-port without changes.
+while a predicate can just test both. px also says outright that a Linux pipe's
+name identifies nothing, at `px_file.py:85-88`.
 
 ### Unix domain sockets
 
@@ -167,24 +133,17 @@ Measured on a macOS laptop, non-root:
 | `lsof -n -P -w -iTCP -F pfnT0` (the TCP slice's, since superseded) | 0.13 s | — |
 | `lsof -n -w -d cwd -F pfn0` (already in the tree) | 0.22 s | 15 KB |
 
-This is a **second lsof fork**, separate from the cwd one in `cwds.go`. Rejected
-sharing a single full lsof (px's approach) because `-i` scales with socket count
-while full lsof scales with every fd on the machine — the difference that matters
-for root on a busy multi-user Linux box. It also keeps the two page sections
-independently degradable.
+This is a **second lsof fork**, separate from the cwd one in `cwds.go`, and pipes
+have since added a third. Sharing one is still rejected; the cost argument is in
+`GetSocketsByPid()` and the independent-degradation one on `socketListing`, while
+"Deferred" carries the current terms, which the pipe fork changed.
 
-**`-iTCP -iUDP` rather than a plain `-i`.** Both protocols in one fork, and lsof
-ORs its selection criteria so the two `-i` options add up. Not a bare `-i`: on
-macOS that also reports `PICMP` and `PICMPV6` records, which are named `*:*` and
-carry nothing we could say anything about. Verified to yield exactly `PTCP` and
-`PUDP` on both platforms. (Linux 4.99.4 reports no ICMP sockets under `-i`
-anyway, so there the two invocations agree — the narrowing is for macOS.)
-
-**`-Ts` does not narrow the state field down** — verified, the queue sizes come
-along anyway. Which is why the parser dispatches on the `ST=` value prefix.
-
-Partial lsof failure is business as usual: use whatever came back, log the rest.
-See `cwds.go` for the established handling.
+Two measurements behind the flags `sockets.go` documents. **`-iTCP -iUDP`** was
+verified to yield exactly `PTCP` and `PUDP` on both platforms, and Linux 4.99.4
+reports no ICMP sockets under a bare `-i` anyway, so narrowing away macOS's
+`PICMP` records is what that buys. **`-Ts` does not narrow the state field down**,
+also verified — the queue sizes come along regardless, which is why the parser
+dispatches on the `ST=` value prefix.
 
 ## Verified on Linux
 
@@ -243,33 +202,11 @@ thanks to `-w`, and exactly one PID reported — our own, its connection the rig
 way round. Its peer comes back as a bare `127.0.0.1` with no PID, the listening
 process being invisible from there.
 
-**The container recipe** *(run 4)*, `--privileged` being what allows the two
-`mount` calls further down:
-
-```
-docker run --rm -it --privileged -v "$PWD:/src" -v ftop-gomod:/go/pkg/mod \
-  -v ftop-gobuild:/root/.cache/go-build -w /src golang:1.25 bash
-# then, inside:
-apt-get update && apt-get install -y lsof procps wtmpdb
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-  | sh -s -- -b "$(go env GOPATH)"/bin v2.8.0
-wtmpdb boot   # give "last" a database to read, see below
-./test.sh
-```
-
-The image has neither `lsof` nor the `ps` ftop forks, and `test.sh` wants
-golangci-lint v2.8.0, the version `.github/workflows/linux-ci.yml` installs. Two
-more things that cost a while to find, both about the container rather than about
-ftop. On Debian 13 the `last` that `loginhistory` forks comes from `wtmpdb` rather
-than from `util-linux`, and it exits 1 with no database at all, so
-`TestGetUsersAtSmoke` needs `wtmpdb boot` once. And run `test.sh` from the
-`docker run` shell rather than through a later `docker exec`: an exec'd process has
-no parent inside the container's PID namespace, so `TestGetAll`'s walk up to init
-lands on the shell instead of on PID 1. With those in place the whole suite is
-green.
-
-**The pipe display, exercised by hand** *(run 4)*. Three shells holding FIFO ends
-plus one real pipeline, which is the shape the two matching fixes are about:
+**The pipe display, exercised by hand** *(run 4)*. The container recipe has moved
+to `AGENTS.md`, being useful for verifying anything on Linux rather than pipes in
+particular; `--privileged` is what allows the two `mount` calls below. Three shells
+holding FIFO ends plus one real pipeline, which is the shape the two matching fixes
+are about:
 
 ```
 mkdir -p /mnt/a /mnt/b
@@ -337,10 +274,10 @@ The rule, its rationale and its three known limits are all in
 reproduced with GNU netcat 0.7.1, which does hold only the accepted socket. One
 decision the code doesn't carry:
 
-Self-connections (a process dialing its own listening port) are **shown, once** —
-deduped by keeping the socket whose local endpoint sorts first. px drops these
-entirely (`px_ipc_map.py:173`), which loses information a diagnostic page should
-surface. Showing both sides would report `(×2)` for one connection.
+Self-connections (a process dialing its own listening port) are **shown, once**;
+`isTheFarEndOfOurOwnConnection()` says which of the two sockets stands for it. px
+drops these entirely (`px_ipc_map.py:173`), which loses information a diagnostic
+page should surface, and showing both sides would report `(×2)` for one connection.
 
 ## Aggregation
 
@@ -368,25 +305,22 @@ taking a `peerLabel` callback rather than the same code twice. The sections keep
 rendering their own error and empty states, which is the independence that
 mattered. The layout rules are all in `writeConnectionLines()`.
 
-```
-Inter Process Communication
-<Detected: TCP, UDP. Not detected: pipes, unix sockets>
-curl(999) --> picked(42)                tcp 8080
-              picked(42) --> sshd(123)  tcp 22
-              picked(42) <?> peer(99)   udp 9001
+What the two sections look like is no longer drawn here. The page tests assert
+whole blocks after ANSI stripping, so their expected strings are the mockups and
+cannot rot — `pageipcconnections_test.go` and `pagenetworkconnections_test.go`,
+covering both arrows, `<?>`, counts and the listening row. One of them, so that
+this section is readable without opening them:
 
-Network Connections
-            picked(42)                     tcp 8080 (listening)
-1.2.3.4 --> picked(42)                     tcp 8080 (×12)
-            picked(42) --> api.github.com  tcp 443 (×7)
-            picked(42) <?> dns.google      udp 53
+```
+<Detected: TCP, UDP, pipes. Not detected: unix sockets>
+grep(1234) --> picked(42)                 pipe
+               picked(42) --> sort(5678)  pipe
+               picked(42) --> sshd(1)     tcp 22
 ```
 
-The UDP line in the IPC block needs **both** ends to have connected their
-sockets, which is the uncommon shape — see "Deferred" for why a local UDP server
-lands in Network Connections under an address instead. Both mockups are drawn to
-the real column rules, two spaces between columns and both arrows five columns
-wide, so they can be checked against `writeConnectionLines()` rather than trusted.
+A UDP line in the IPC block needs **both** ends to have connected their sockets,
+which is the uncommon shape — see "Deferred" for why a local UDP server lands in
+Network Connections under an address instead.
 
 The arrow direction and the never-an-address rule for the description column are
 both stated where they are implemented, in `pageconnections.go`. The two rules
@@ -398,24 +332,6 @@ that live nowhere else:
   explains.
 - The caveat line is **IPC section only** — Network Connections has nothing
   missing. Grow it as kinds land and delete it when nothing is missing.
-
-## Tests
-
-Two conventions that aren't obvious from the repo's other tests:
-
-- Page assertions are **full-block equality after ANSI stripping** (`stripAnsi()`
-  and `sectionBody()` in `pagetext_test.go`), not `stringsContains` fragments.
-  Alignment is the feature here, and a test asserting `"sshd(123)"` passes whether
-  or not the columns line up. The expected string doubles as documentation of what
-  the section looks like. `stringsContains` stays for error and empty paths, where
-  there is no layout.
-- Page sections have `var` seams for **both** the lsof call and the DNS
-  resolution. Without a DNS seam every page test does real network lookups.
-
-Parser tests use inline NUL-terminated strings, per `cwds_test.go`. This repo has
-no `testdata/` directory and shouldn't grow one for this.
-
-`./test.sh` before any PR, per `AGENTS.md`.
 
 ## Deferred, deliberately
 

--- a/IPC-DESIGN.md
+++ b/IPC-DESIGN.md
@@ -58,20 +58,33 @@ the sections start sharing.
 Two mechanisms, verified against real pipe pairs on both platforms:
 
 ```
-Linux   tFIFO  i16466  npipe                 ar / aw
+Linux   tFIFO  D0xe  i16466  npipe            ar / aw
 macOS   tPIPE  d0x48d4efd2cbb7a037  n->0x7249c1bc766ed78e
 ```
 
-Linux matches on **inode plus opposing `r`/`w` access**; the name is the literal
-string `pipe` and identifies nothing, which px says outright at
-`px_file.py:85-88`. macOS matches on **our peer's kernel address against their
-device**: `theirs.Device == strings.TrimPrefix(ours.Name, "->")`.
+Linux matches on **file system device plus inode plus opposing `r`/`w` access**;
+the name is the literal string `pipe` and identifies nothing, which px says
+outright at `px_file.py:85-88`. The device is the uppercase `D` field, and it is
+needed because an inode number is only unique within one file system: a FIFO on
+each of two fresh tmpfs mounts is inode 2 on both. macOS matches on **our peer's
+kernel address against their device**: `theirs.Device ==
+strings.TrimPrefix(ours.Name, "->")`.
 
-**These need no `GOOS` switch.** The field sets are disjoint — measured on a
-quiet macOS laptop, 358 of 358 `PIPE` records carry a device and none carries an
-inode; in a Debian container, 0 of 20 `FIFO` records carry a device and all 20
-carry an inode. So neither platform can satisfy the other's condition, and one
-predicate that ORs the two clauses is correct everywhere.
+**These need no `GOOS` switch.** What makes the two clauses disjoint is
+`PeerDevice`, which is populated from an `n->0x...` name and from nothing else:
+measured on a quiet macOS laptop, 358 of 358 `PIPE` records carry such a name and
+none carries an inode, while in a Debian container all 20 `FIFO` records carry an
+inode and not one is named that way — Linux spells an anonymous pipe `npipe` and a
+named FIFO by its path. So neither platform can satisfy the other's condition, and
+one predicate that ORs the two clauses is correct everywhere.
+
+Note that a *device* being present says nothing about which clause applies, the
+two fields being different things. Lowercase `d` is empty for every `FIFO` record
+on both platforms — that is what the earlier "0 of 20 `FIFO` records carry a
+device" measurement really established — while uppercase `D` is a file system
+device that Linux reports for every pipe, anonymous ones living on pipefs and
+sharing `0xe`. macOS reports no `D` for a pipe of either kind, so there two pipes
+are told apart by their inodes and kernel addresses alone.
 
 **Do not copy px's four index maps** (`px_ipc_map.py:191-220`). They exist to
 make `_get_other_end_pids()` O(1) per file because Python makes the scan
@@ -162,7 +175,7 @@ See `cwds.go` for the established handling.
 
 ## Verified on Linux
 
-Three runs, all in a container on Debian with **lsof 4.99.4** as root. Runs 1 and
+Four runs, all in a container on Debian with **lsof 4.99.4** as root. Runs 1 and
 2 used `python:3-slim` (Debian 13.6): the first before the implementation
 existed, with real loopback connections — an IPv4 listener on `127.0.0.1:8080`,
 an IPv6 listener on `[::1]:8081`, a wildcard listener on `0.0.0.0:8082`, a client
@@ -170,8 +183,8 @@ for each, and a client with 8 threads holding one connection — and the second
 against the finished TCP code, adding `sshd` (**OpenSSH 10.0p2**) with a live ssh
 session, a socket held on two file descriptors, and 400 connections' worth of
 load. Run 3 verified UDP, and ran the Go test suite itself in a `golang:1.25`
-container against the real Linux lsof. Findings are marked with the run they came
-from where it matters.
+container against the real Linux lsof. Run 4 did the same for pipes. Findings are
+marked with the run they came from where it matters.
 
 Most of what those runs established has since collapsed into the test suite:
 reversed-pair matching for both address families and both protocols, IPv6
@@ -216,6 +229,68 @@ that grows with the machine, and this machine had a few dozen processes.
 thanks to `-w`, and exactly one PID reported — our own, its connection the right
 way round. Its peer comes back as a bare `127.0.0.1` with no PID, the listening
 process being invisible from there.
+
+**The container recipe** *(run 4)*, `--privileged` being what allows the two
+`mount` calls further down:
+
+```
+docker run --rm -it --privileged -v "$PWD:/src" -v ftop-gomod:/go/pkg/mod \
+  -v ftop-gobuild:/root/.cache/go-build -w /src golang:1.25 bash
+# then, inside:
+apt-get update && apt-get install -y lsof procps wtmpdb
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+  | sh -s -- -b "$(go env GOPATH)"/bin v2.8.0
+wtmpdb boot   # give "last" a database to read, see below
+./test.sh
+```
+
+The image has neither `lsof` nor the `ps` ftop forks, and `test.sh` wants
+golangci-lint v2.8.0, the version `.github/workflows/linux-ci.yml` installs. Two
+more things that cost a while to find, both about the container rather than about
+ftop. On Debian 13 the `last` that `loginhistory` forks comes from `wtmpdb` rather
+than from `util-linux`, and it exits 1 with no database at all, so
+`TestGetUsersAtSmoke` needs `wtmpdb boot` once. And run `test.sh` from the
+`docker run` shell rather than through a later `docker exec`: an exec'd process has
+no parent inside the container's PID namespace, so `TestGetAll`'s walk up to init
+lands on the shell instead of on PID 1. With those in place the whole suite is
+green.
+
+**The pipe display, exercised by hand** *(run 4)*. Three shells holding FIFO ends
+plus one real pipeline, which is the shape the two matching fixes are about:
+
+```
+mkdir -p /mnt/a /mnt/b
+mount -t tmpfs tmpfs /mnt/a && mount -t tmpfs tmpfs /mnt/b
+mkfifo /mnt/a/f /mnt/b/f
+stat -c 'dev=%D ino=%i %n' /mnt/a/f /mnt/b/f
+bash -c 'exec 3<>/mnt/a/f; exec 4<>/mnt/b/f; sleep 3000' &  # an end of each
+bash -c 'exec 3</mnt/a/f;  exec 4</mnt/b/f;  sleep 3000' &  # the other ends
+bash -c 'exec 3>/mnt/a/f;  exec 4<>/mnt/a/f; sleep 3000' &  # w and u, one FIFO
+tail -f /etc/services | sort | nl &                         # a real pipeline
+./ftop.sh
+```
+
+`stat` reports `dev=37 ino=2` and `dev=38 ino=2`, so the inode collision takes two
+`mount` calls rather than any luck — each FIFO is the first file on a file system
+that numbers from scratch. Open the shells' pages and the two holding an end of
+each FIFO report one another as `pipe (×2)`; the `w`-and-`u` shell draws one line
+per peer, `<?>` because its own two ends let it both write the pipe and read it,
+plus a line to itself for the FIFO it can write on fd 3 and read back on fd 4. On
+the inode alone those pages read `pipe` with no count and five lines instead of
+three, two of them arrows the `u` end contradicts, which is what the two fixes
+close.
+
+The pipeline gets its arrows, `tail(7612) --> sort(7613)` and
+`sort(7613) --> nl(7614)`, Linux reporting the access modes macOS won't — the same
+pipeline that reads `<?>` on a laptop, see "Deferred" on taking that direction from
+the kernel instead.
+
+**Both socket sections degrade on their own** *(run 4)*, which is the independence
+the two-listing decision was for, observed for the first time. A container with no
+internet files at all makes `lsof -iTCP -iUDP` exit 1 with nothing on stdout, so
+the socket listing fails outright while the unfiltered pipe listing succeeds: the
+IPC section renders `<Unable to list sockets: ...>` and then its pipe lines below
+it, and Network Connections renders the error alone.
 
 Still unverified: behaviour on a busy multi-user box, which is the environment
 this is ultimately for. Run 2 loaded the container up with sockets and open
@@ -386,18 +461,6 @@ no `testdata/` directory and shouldn't grow one for this.
   Connections about half the time. Direction inference elsewhere survives it,
   since `listenSets()` reads the raw listing rather than the deduplicated one.
   Predates UDP; cheap to close.
-- **Two pipe matching fixes held for the Linux pass**, both waiting on the same
-  field. `arePipeEnds()` and `pipeIdentity()` key on the inode alone, so two named
-  FIFOs on different file systems sharing an inode number are both fabricated
-  into a pair *and* counted as one pipe — a peer at the end of both gets `(×1)`
-  where it earned `(×2)`. The device tells them apart, and Linux is where a FIFO
-  carries one; macOS reports no device for a FIFO at all, so there is nothing to
-  key on and no way to write a fixture until the Linux pass. Separately, two ends
-  of one pipe held by the same process can disagree about its direction, a `u`
-  end being `DirectionUnknown` where a `w` end of that pipe is
-  `DirectionOutgoing`, and since direction is part of what identifies a line that
-  pipe draws two lines to the one peer. Both are recorded as known limits on the
-  functions themselves.
 - **Pipe direction on macOS, taken from the kernel rather than from lsof.** macOS
   lsof reports no access mode for a `PIPE` record, so every anonymous pipe there
   is `DirectionUnknown` and renders `<?>`. `tail -f /etc/services | sort | nl`

--- a/IPC-DESIGN.md
+++ b/IPC-DESIGN.md
@@ -31,7 +31,7 @@ alternatives, verification findings, and the plan for what isn't built yet.
 **UDP: done.** Same lsof call, same parser, same reversed-pair peer matching —
 lsof names a UDP socket in exactly the format it names a TCP one in, so nothing
 new was needed for matching and there is no platform specific code. What UDP
-added: a `Protocol` field, `DirectionUnknown` rendered `<->`, and the protocol as
+added: a `Protocol` field, `DirectionUnknown` rendered `<?>`, and the protocol as
 part of the keys identifying a connection. Bound but unconnected UDP sockets are
 dropped, see "Deferred" below.
 
@@ -88,7 +88,8 @@ Data flows from the writer to the reader, which is a direction worth an arrow an
 which maps onto the existing split — write end outgoing, read end incoming, so
 `grep(1234) --> sort(5678)` from either end's page. Linux has the access mode
 already, since matching needs `a` anyway; wherever it turns out not to be
-available, fall back to `DirectionUnknown` and `<->`.
+available, fall back to `DirectionUnknown` and `<?>` — see "Deferred" for where
+macOS keeps the access mode when lsof won't hand it over.
 
 Pipes have no port, and `connectionDescription()` appends one unconditionally.
 So it needs a no-port case, rendering the bare protocol: `pipe`, and `pipe (×3)`
@@ -284,13 +285,13 @@ Inter Process Communication
 <Detected: TCP, UDP. Not detected: pipes, unix sockets>
 curl(999) --> picked(42)                tcp 8080
               picked(42) --> sshd(123)  tcp 22
-              picked(42) <-> peer(99)   udp 9001
+              picked(42) <?> peer(99)   udp 9001
 
 Network Connections
             picked(42)                     tcp 8080 (listening)
 1.2.3.4 --> picked(42)                     tcp 8080 (×12)
             picked(42) --> api.github.com  tcp 443 (×7)
-            picked(42) <-> dns.google      udp 53
+            picked(42) <?> dns.google      udp 53
 ```
 
 The UDP line in the IPC block needs **both** ends to have connected their
@@ -343,7 +344,7 @@ no `testdata/` directory and shouldn't grow one for this.
   2. **Its clients can't name it either.** A UDP server serves every client from
      one bound socket and never connects it, so there is no reversed pair to
      match. The client's peer comes back as an address with no PID, which puts it
-     in *Network Connections* reading `picked(42) <-> localhost  udp 53` — with
+     in *Network Connections* reading `picked(42) <?> localhost  udp 53` — with
      the server sitting right there in the same lsof listing, unnamed.
 
   So for UDP the IPC section stays empty unless both ends happen to have
@@ -385,3 +386,64 @@ no `testdata/` directory and shouldn't grow one for this.
   Connections about half the time. Direction inference elsewhere survives it,
   since `listenSets()` reads the raw listing rather than the deduplicated one.
   Predates UDP; cheap to close.
+- **Two pipe matching fixes held for the Linux pass**, both waiting on the same
+  field. `arePipeEnds()` and `pipeIdentity()` key on the inode alone, so two named
+  FIFOs on different file systems sharing an inode number are both fabricated
+  into a pair *and* counted as one pipe — a peer at the end of both gets `(×1)`
+  where it earned `(×2)`. The device tells them apart, and Linux is where a FIFO
+  carries one; macOS reports no device for a FIFO at all, so there is nothing to
+  key on and no way to write a fixture until the Linux pass. Separately, two ends
+  of one pipe held by the same process can disagree about its direction, a `u`
+  end being `DirectionUnknown` where a `w` end of that pipe is
+  `DirectionOutgoing`, and since direction is part of what identifies a line that
+  pipe draws two lines to the one peer. Both are recorded as known limits on the
+  functions themselves.
+- **Pipe direction on macOS, taken from the kernel rather than from lsof.** macOS
+  lsof reports no access mode for a `PIPE` record, so every anonymous pipe there
+  is `DirectionUnknown` and renders `<?>`. `tail -f /etc/services | sort | nl`
+  shows as `tail(40504) <?> sort(40505)  pipe` when the truth is plainly
+  `tail --> sort`.
+
+  **Not a matter of asking lsof for the right field.** `+fg` is lsof's file-flag
+  option, and it fills that column in for `CHR` and `REG` while leaving it blank
+  for `PIPE`; the FD number carries no `r`/`w` suffix either. Both ends of a real
+  pipeline, on macOS lsof 4.91:
+
+  ```
+  tail  40697  0r  CHR   R;SH          /dev/null     <- flags reported
+  tail  40697  1   PIPE                ->0x8512...   <- blank
+  sort  40698  0   PIPE                ->0xe272...   <- blank
+  sort  40698  2w  CHR   W,0x10000;SH  /dev/null     <- flags reported
+  ```
+
+  **The kernel knows.** `proc_pidfdinfo(pid, fd, PROC_PIDFDPIPEINFO)` fills in a
+  `proc_fileinfo` whose `fi_openflags` carries FREAD/FWRITE, verified against
+  that same pipeline:
+
+  ```
+  tail(40697) fd 1  fi_openflags=0x10002  FWRITE  handle=0xe272559b6a8c5e34  peer=0x8512e4a289d94ded
+  sort(40698) fd 0  fi_openflags=0x1      FREAD   handle=0x8512e4a289d94ded  peer=0xe272559b6a8c5e34
+  ```
+
+  `pipe_handle` and `pipe_peerhandle` are the same two numbers lsof prints as the
+  `DEVICE` and the `->` name, so this is the pipe end we already have with the
+  direction attached, not a second identity to join on.
+
+  Cheaper than a new data source usually is. cgo is already a macOS dependency —
+  `test.sh` builds both darwin targets with `CGO_ENABLED=1`, and
+  `sysload_darwin.go` is the established `//go:build darwin` plus inline C
+  pattern. The change lands entirely in `GetPipeEndsByPid()`, filling in the
+  `Access` lsof left empty, so `arePipeEnds()`, `pipeDirection()` and every one of
+  their tests are untouched. Linux keeps taking the access mode from lsof and
+  needs nothing. Cost is one syscall per pipe end, around 300 on a quiet laptop,
+  against the 0.36 s the unfiltered lsof already spends.
+
+  Guard the race between the lsof fork and the syscall by requiring the returned
+  `pipe_handle` to equal the `Device` lsof reported — an fd can be closed and
+  reopened in between, and then the flags describe some other file entirely.
+
+  Unverified: how this degrades for processes we don't own. `proc_pidfdinfo`
+  enforces a same-uid-or-root check, so EPERM and a fall back to
+  `DirectionUnknown` is what to expect, matching how lsof already degrades — but
+  the laptop this was measured on had no root-owned process holding a pipe to
+  probe, so that is reasoning rather than a measurement.

--- a/internal/ftop/pageconnections.go
+++ b/internal/ftop/pageconnections.go
@@ -8,17 +8,18 @@ import (
 	"github.com/walles/ftop/internal/processes"
 )
 
-// Writes one line per connection, with the arrows pointing from whoever dialed
-// to whoever was dialed. That is the one directional fact about a connection
-// worth knowing, and it tells the reader which side is the service. Connections
-// nobody can tell the direction of, every UDP one included, get an arrow pointing
-// both ways instead.
+// Writes one line per connection, with the arrows pointing the way
+// processes.Direction means them: from whoever dialed to whoever was dialed for a
+// socket, which tells the reader which side is the service, and from the writer
+// to the reader for a pipe, which is the way the data goes. Connections nobody
+// can tell the direction of, every UDP one included, get "<?>" instead of an
+// arrow.
 //
 // peerLabel is what to call the peer of a connection. It is never asked about a
 // listening port, since nobody is at the other end of one of those.
 //
 // The connections are written in the order they come in, so hand them over
-// sorted, see processes.NetworkConnections().
+// sorted, see processes.SortConnections().
 //
 // The columns are only as wide as these connections need them to be, and are
 // measured over these connections alone: two sections' worth of lines are far
@@ -66,11 +67,15 @@ func (u *Ui) writeConnectionLines(
 			line.dialer = peerLabel(connection.Peer)
 
 		default:
-			// Both arrows are the same number of columns wide, so which one a line
-			// gets doesn't disturb the alignment of the lines around it.
+			// All three markers are the same number of columns wide, so which one
+			// a line gets doesn't disturb the alignment of the lines around it.
 			arrow := " --> "
 			if connection.Direction == processes.DirectionUnknown {
-				arrow = " <-> "
+				// Not "<->", which draws an arrow pointing both ways and so
+				// claims data flows both ways. That is a different fact from not
+				// knowing which way it flows, and for a pipe it is plainly false:
+				// a pipe carries data one way, we just can't always say which.
+				arrow = " <?> "
 			}
 
 			peer := peerLabel(connection.Peer)
@@ -105,11 +110,17 @@ func (u *Ui) writeConnectionLines(
 // The rightmost column of a connection line: the protocol and the port being
 // served, plus whatever makes this line more than one plain connection.
 //
+// A connection carried by something that has no ports, a pipe being one, gets
+// the bare protocol instead.
+//
 // Never an address: for a connection between processes the address is always
 // loopback and says nothing, and for a remote peer it is in the peer column
 // already.
 func connectionDescription(connection processes.Connection) string {
-	description := string(connection.Protocol) + " " + strconv.Itoa(connection.Port)
+	description := string(connection.Protocol)
+	if connection.Port != 0 {
+		description += " " + strconv.Itoa(connection.Port)
+	}
 
 	if connection.Listening {
 		return description + " (listening)"

--- a/internal/ftop/pagecwdfriends.go
+++ b/internal/ftop/pagecwdfriends.go
@@ -4,6 +4,7 @@ import (
 	"github.com/walles/ftop/internal/processes"
 )
 
+// Seam for testing, see the ones in pageprocessinfo.go
 var getCwdsByPid = processes.GetCwdsByPid
 
 func (u *Ui) cwdFriendsForPaging(

--- a/internal/ftop/pageipcconnections.go
+++ b/internal/ftop/pageipcconnections.go
@@ -14,6 +14,7 @@ func (u *Ui) ipcConnectionsForPaging(
 	currentProcess *processes.Process,
 	allProcesses []*processes.Process,
 	sockets socketListing,
+	pipes pipeListing,
 	pt *pageText,
 ) {
 	const title = "Inter Process Communication"

--- a/internal/ftop/pageipcconnections.go
+++ b/internal/ftop/pageipcconnections.go
@@ -2,6 +2,7 @@ package ftop
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/walles/ftop/internal/processes"
 )
@@ -21,19 +22,29 @@ func (u *Ui) ipcConnectionsForPaging(
 
 	pt.writeTitle(title)
 
+	// Two lsof invocations, so either one can fail while the other returns
+	// something worth showing.
 	if sockets.err != nil {
-		// Without a listing there is nothing for the caveat below to be a caveat
-		// about, so the error is all there is to say.
 		pt.writeLine("<Unable to list sockets: " + sockets.err.Error() + ">")
+	}
+
+	if pipes.err != nil {
+		pt.writeLine("<Unable to list pipes: " + pipes.err.Error() + ">")
+	}
+
+	if sockets.err != nil && pipes.err != nil {
+		// With no listing at all there is nothing for the caveat below to be a
+		// caveat about, so the errors are all there is to say.
 		return
 	}
 
 	// Above the connections rather than below them: a caveat that changes how a
 	// list is read has to arrive before the list, and this page goes into a pager
-	// where the reader may never reach the bottom. Grow this as more kinds of IPC
-	// land, and delete it once nothing is missing.
-	pt.writeLine("<Detected: TCP, UDP. Not detected: pipes, unix sockets>")
+	// where the reader may never reach the bottom.
+	pt.writeLine(ipcCaveat(sockets.err == nil, pipes.err == nil))
 
+	// A failed listing arrives as a nil map, which both of these have nothing to
+	// say about, so neither call needs guarding.
 	var ipcConnections []processes.Connection
 	for _, connection := range processes.NetworkConnections(currentProcess, allProcesses, sockets.byPid) {
 		if connection.Peer.Pid == 0 {
@@ -45,12 +56,43 @@ func (u *Ui) ipcConnectionsForPaging(
 		ipcConnections = append(ipcConnections, connection)
 	}
 
+	// No such partitioning for pipes: a pipe is between processes by nature, so
+	// every one of these belongs here.
+	pipeConnections := processes.PipeConnections(currentProcess, allProcesses, pipes.byPid)
+	ipcConnections = append(ipcConnections, pipeConnections...)
+
+	// Two sorted lists appended is not a sorted list, and the sections' blocks
+	// are what the ordering is for.
+	processes.SortConnections(ipcConnections)
+
 	if len(ipcConnections) == 0 {
 		pt.writeLine("<No connections found>")
 		return
 	}
 
 	u.writeConnectionLines(currentProcess, ipcConnections, processPeerLabel, pt)
+}
+
+// The caveat line, naming the kinds of IPC this listing does and doesn't cover.
+//
+// haveSockets and havePipes say which listings we got, a failed one being just
+// as undetected as an unimplemented kind for the reader's purposes. At least one
+// of them has to be true: with neither there is nothing for a caveat to be a
+// caveat about, and the caller has errors to print instead.
+//
+// Grow this as more kinds land, and delete it once nothing is missing.
+func ipcCaveat(haveSockets bool, havePipes bool) string {
+	var detected []string
+
+	if haveSockets {
+		detected = append(detected, "TCP", "UDP")
+	}
+
+	if havePipes {
+		detected = append(detected, "pipes")
+	}
+
+	return "<Detected: " + strings.Join(detected, ", ") + ". Not detected: unix sockets>"
 }
 
 // What to call a peer process: its command name and PID, or its PID alone when

--- a/internal/ftop/pageipcconnections.go
+++ b/internal/ftop/pageipcconnections.go
@@ -75,24 +75,35 @@ func (u *Ui) ipcConnectionsForPaging(
 
 // The caveat line, naming the kinds of IPC this listing does and doesn't cover.
 //
-// haveSockets and havePipes say which listings we got, a failed one being just
-// as undetected as an unimplemented kind for the reader's purposes. At least one
-// of them has to be true: with neither there is nothing for a caveat to be a
-// caveat about, and the caller has errors to print instead.
+// haveSockets and havePipes say which listings we got, the kinds from a failed
+// one going among the undetected: missing from the list below is missing from the
+// list below, whether because we couldn't look or because nobody implemented
+// looking. At least one of them has to be true: with neither there is nothing for
+// a caveat to be a caveat about, and the caller has errors to print instead.
 //
 // Grow this as more kinds land, and delete it once nothing is missing.
 func ipcCaveat(haveSockets bool, havePipes bool) string {
 	var detected []string
+	var undetected []string
 
 	if haveSockets {
 		detected = append(detected, "TCP", "UDP")
+	} else {
+		undetected = append(undetected, "TCP", "UDP")
 	}
 
 	if havePipes {
 		detected = append(detected, "pipes")
+	} else {
+		undetected = append(undetected, "pipes")
 	}
 
-	return "<Detected: " + strings.Join(detected, ", ") + ". Not detected: unix sockets>"
+	// Last, so that the kinds we do implement stay together at the front however
+	// many of them failed.
+	undetected = append(undetected, "unix sockets")
+
+	return "<Detected: " + strings.Join(detected, ", ") +
+		". Not detected: " + strings.Join(undetected, ", ") + ">"
 }
 
 // What to call a peer process: its command name and PID, or its PID alone when

--- a/internal/ftop/pageipcconnections_test.go
+++ b/internal/ftop/pageipcconnections_test.go
@@ -11,6 +11,12 @@ import (
 	"github.com/walles/moor/v2/twin"
 )
 
+// No pipes, for the tests that are about sockets
+var noPipes = pipeListing{byPid: map[int][]processes.PipeEnd{}}
+
+// No sockets, for the tests that are about pipes
+var noSockets = socketListing{byPid: map[int][]processes.Socket{}}
+
 // Connections to other processes, one line each, with the arrows pointing from
 // whoever dialed to whoever was dialed — both ways for the UDP peer, since UDP says
 // nothing about who dialed whom. The listening socket on 8080 and the connection to
@@ -44,16 +50,114 @@ func TestIpcConnectionsForPagingListsProcessPeers(t *testing.T) {
 	var page strings.Builder
 	pt := pageText{out: &page}
 
-	ui.ipcConnectionsForPaging(picked, allProcesses, sockets, &pt)
+	ui.ipcConnectionsForPaging(picked, allProcesses, sockets, noPipes, &pt)
 
 	expected := "" +
-		"<Detected: TCP, UDP. Not detected: pipes, unix sockets>\n" +
+		"<Detected: TCP, UDP, pipes. Not detected: unix sockets>\n" +
 		"curl(999) --> picked(42)                   tcp 8080\n" +
 		"              picked(42) --> sshd(1)       tcp 22\n" +
 		"              picked(42) <-> dnsmasq(777)  udp 53\n"
 	assert.Equal(t, sectionBody(page.String()), expected)
 
 	assert.Equal(t, stringsContains(page.String(), "──Inter Process Communication──"), true)
+}
+
+// Pipes and sockets share the section, and the lines are sorted together rather
+// than one kind after the other: incoming first, then outgoing, and each of
+// those blocks stays one protocol at a time.
+//
+// Data flows from the writer to the reader, so the writing end is the outgoing
+// one — which makes the arrow point the way the data goes.
+func TestIpcConnectionsForPagingListsPipes(t *testing.T) {
+	sockets := socketListing{byPid: map[int][]processes.Socket{
+		42: {{Fd: "5", Protocol: processes.ProtocolTcp, Local: "127.0.0.1:54322", Remote: "127.0.0.1:22"}},
+		1: {
+			{Fd: "9", Protocol: processes.ProtocolTcp, Local: "127.0.0.1:22", Listening: true},
+			{Fd: "10", Protocol: processes.ProtocolTcp, Local: "127.0.0.1:22", Remote: "127.0.0.1:54322"},
+		},
+	}}
+
+	pipes := pipeListing{byPid: map[int][]processes.PipeEnd{
+		1234: {{Fd: "1", Access: processes.PipeAccessWrite, Inode: "16466"}},
+		42: {
+			{Fd: "0", Access: processes.PipeAccessRead, Inode: "16466"},
+			{Fd: "1", Access: processes.PipeAccessWrite, Inode: "16467"},
+		},
+		5678: {{Fd: "0", Access: processes.PipeAccessRead, Inode: "16467"}},
+	}}
+
+	picked := &processes.Process{Pid: 42, Cmdline: "picked"}
+	allProcesses := []*processes.Process{
+		picked,
+		{Pid: 1, Cmdline: "sshd"},
+		{Pid: 1234, Cmdline: "grep"},
+		{Pid: 5678, Cmdline: "sort"},
+	}
+
+	ui := NewUi(twin.NewFakeScreen(80, 24), themes.NewTheme("auto", nil), "")
+	var page strings.Builder
+	pt := pageText{out: &page}
+
+	ui.ipcConnectionsForPaging(picked, allProcesses, sockets, pipes, &pt)
+
+	expected := "" +
+		"<Detected: TCP, UDP, pipes. Not detected: unix sockets>\n" +
+		"grep(1234) --> picked(42)                 pipe\n" +
+		"               picked(42) --> sort(5678)  pipe\n" +
+		"               picked(42) --> sshd(1)     tcp 22\n"
+	assert.Equal(t, sectionBody(page.String()), expected)
+}
+
+// macOS lsof won't say which end of a pipe writes, so there the arrow points
+// both ways, the way it does for UDP.
+func TestIpcConnectionsForPagingPipeOfUnknownDirection(t *testing.T) {
+	pipes := pipeListing{byPid: map[int][]processes.PipeEnd{
+		42:   {{Fd: "1", Device: "0xaaaa", PeerDevice: "0xbbbb"}},
+		5678: {{Fd: "0", Device: "0xbbbb", PeerDevice: "0xaaaa"}},
+	}}
+
+	picked := &processes.Process{Pid: 42, Cmdline: "picked"}
+	allProcesses := []*processes.Process{picked, {Pid: 5678, Cmdline: "sort"}}
+
+	ui := NewUi(twin.NewFakeScreen(80, 24), themes.NewTheme("auto", nil), "")
+	var page strings.Builder
+	pt := pageText{out: &page}
+
+	ui.ipcConnectionsForPaging(picked, allProcesses, noSockets, pipes, &pt)
+
+	expected := "" +
+		"<Detected: TCP, UDP, pipes. Not detected: unix sockets>\n" +
+		"picked(42) <-> sort(5678)  pipe\n"
+	assert.Equal(t, sectionBody(page.String()), expected)
+}
+
+// A pipe has no port, so its description is the bare word "pipe". Several pipes
+// to the same process still aggregate into one line with a count.
+func TestIpcConnectionsForPagingSeveralPipesToOnePeer(t *testing.T) {
+	pipes := pipeListing{byPid: map[int][]processes.PipeEnd{
+		42: {
+			{Fd: "1", Access: processes.PipeAccessWrite, Inode: "16466"},
+			{Fd: "2", Access: processes.PipeAccessWrite, Inode: "16467"},
+		},
+		5678: {
+			{Fd: "0", Access: processes.PipeAccessRead, Inode: "16466"},
+			{Fd: "3", Access: processes.PipeAccessRead, Inode: "16467"},
+		},
+	}}
+
+	picked := &processes.Process{Pid: 42, Cmdline: "picked"}
+	allProcesses := []*processes.Process{picked, {Pid: 5678, Cmdline: "sort"}}
+
+	ui := NewUi(twin.NewFakeScreen(80, 24), themes.NewTheme("auto", nil), "")
+	var page strings.Builder
+	pt := pageText{out: &page}
+
+	ui.ipcConnectionsForPaging(picked, allProcesses, noSockets, pipes, &pt)
+
+	expected := "" +
+		"<Detected: TCP, UDP, pipes. Not detected: unix sockets>\n" +
+		"picked(42) --> sort(5678)  pipe (×2)\n"
+	assert.Equal(t, sectionBody(page.String()), expected)
 }
 
 // The picked process is what the whole page is about, and every other section
@@ -71,7 +175,7 @@ func TestIpcConnectionsForPagingHighlightsThePickedProcess(t *testing.T) {
 	var page strings.Builder
 	pt := pageText{out: &page}
 
-	ui.ipcConnectionsForPaging(picked, allProcesses, sockets, &pt)
+	ui.ipcConnectionsForPaging(picked, allProcesses, sockets, noPipes, &pt)
 
 	assert.Equal(t, stringsContains(page.String(), ui.highlight("picked(42)")), true)
 }
@@ -93,10 +197,10 @@ func TestIpcConnectionsForPagingNamelessPeer(t *testing.T) {
 	var page strings.Builder
 	pt := pageText{out: &page}
 
-	ui.ipcConnectionsForPaging(picked, []*processes.Process{picked}, sockets, &pt)
+	ui.ipcConnectionsForPaging(picked, []*processes.Process{picked}, sockets, noPipes, &pt)
 
 	expected := "" +
-		"<Detected: TCP, UDP. Not detected: pipes, unix sockets>\n" +
+		"<Detected: TCP, UDP, pipes. Not detected: unix sockets>\n" +
 		"PID 999 --> picked(42)  tcp 8080\n"
 	assert.Equal(t, sectionBody(page.String()), expected)
 }
@@ -116,10 +220,10 @@ func TestIpcConnectionsForPagingOutgoingOnly(t *testing.T) {
 	var page strings.Builder
 	pt := pageText{out: &page}
 
-	ui.ipcConnectionsForPaging(picked, allProcesses, sockets, &pt)
+	ui.ipcConnectionsForPaging(picked, allProcesses, sockets, noPipes, &pt)
 
 	expected := "" +
-		"<Detected: TCP, UDP. Not detected: pipes, unix sockets>\n" +
+		"<Detected: TCP, UDP, pipes. Not detected: unix sockets>\n" +
 		"picked(42) --> sshd(1)  tcp 22\n"
 	assert.Equal(t, sectionBody(page.String()), expected)
 }
@@ -127,26 +231,25 @@ func TestIpcConnectionsForPagingOutgoingOnly(t *testing.T) {
 // The caveat has to be above the connections: it changes how they are read, and
 // this page goes into a pager where a reader may never reach the bottom.
 func TestIpcConnectionsForPagingNoConnections(t *testing.T) {
-	sockets := socketListing{byPid: map[int][]processes.Socket{}}
-
 	picked := &processes.Process{Pid: 42, Cmdline: "picked"}
 
 	ui := NewUi(twin.NewFakeScreen(80, 24), themes.NewTheme("auto", nil), "")
 	var page strings.Builder
 	pt := pageText{out: &page}
 
-	ui.ipcConnectionsForPaging(picked, []*processes.Process{picked}, sockets, &pt)
+	ui.ipcConnectionsForPaging(picked, []*processes.Process{picked}, noSockets, noPipes, &pt)
 
 	expected := "" +
-		"<Detected: TCP, UDP. Not detected: pipes, unix sockets>\n" +
+		"<Detected: TCP, UDP, pipes. Not detected: unix sockets>\n" +
 		"<No connections found>\n"
 	assert.Equal(t, sectionBody(page.String()), expected)
 }
 
-// Without a socket listing there is nothing for the caveat to be a caveat about,
-// so the error is all there is to say.
+// With no listing at all there is nothing for the caveat to be a caveat about,
+// so the errors are all there is to say.
 func TestIpcConnectionsForPagingShowsErrors(t *testing.T) {
 	sockets := socketListing{err: errors.New("boom")}
+	pipes := pipeListing{err: errors.New("bang")}
 
 	picked := &processes.Process{Pid: 42, Cmdline: "picked"}
 
@@ -154,7 +257,79 @@ func TestIpcConnectionsForPagingShowsErrors(t *testing.T) {
 	var page strings.Builder
 	pt := pageText{out: &page}
 
-	ui.ipcConnectionsForPaging(picked, []*processes.Process{picked}, sockets, &pt)
+	ui.ipcConnectionsForPaging(picked, []*processes.Process{picked}, sockets, pipes, &pt)
 
-	assert.Equal(t, sectionBody(page.String()), "<Unable to list sockets: boom>\n")
+	expected := "" +
+		"<Unable to list sockets: boom>\n" +
+		"<Unable to list pipes: bang>\n"
+	assert.Equal(t, sectionBody(page.String()), expected)
+}
+
+// Two lsof invocations mean either one can fail on its own. What did come back
+// is still worth showing, and the caveat says what this listing is missing on
+// top of what isn't implemented at all.
+func TestIpcConnectionsForPagingPipeListingFailed(t *testing.T) {
+	sockets := socketListing{byPid: map[int][]processes.Socket{
+		42: {{Fd: "3", Protocol: processes.ProtocolTcp, Local: "127.0.0.1:54322", Remote: "127.0.0.1:22"}},
+		1:  {{Fd: "9", Protocol: processes.ProtocolTcp, Local: "127.0.0.1:22", Remote: "127.0.0.1:54322"}},
+	}}
+	pipes := pipeListing{err: errors.New("boom")}
+
+	picked := &processes.Process{Pid: 42, Cmdline: "picked"}
+	allProcesses := []*processes.Process{picked, {Pid: 1, Cmdline: "sshd"}}
+
+	ui := NewUi(twin.NewFakeScreen(80, 24), themes.NewTheme("auto", nil), "")
+	var page strings.Builder
+	pt := pageText{out: &page}
+
+	ui.ipcConnectionsForPaging(picked, allProcesses, sockets, pipes, &pt)
+
+	expected := "" +
+		"<Unable to list pipes: boom>\n" +
+		"<Detected: TCP, UDP. Not detected: unix sockets>\n" +
+		"picked(42) --> sshd(1)  tcp 22\n"
+	assert.Equal(t, sectionBody(page.String()), expected)
+}
+
+// One listing failed and the other found nothing. Both facts matter, and
+// neither one is a reason to stop before saying the other.
+func TestIpcConnectionsForPagingPipeListingFailedAndNoSockets(t *testing.T) {
+	pipes := pipeListing{err: errors.New("boom")}
+
+	picked := &processes.Process{Pid: 42, Cmdline: "picked"}
+
+	ui := NewUi(twin.NewFakeScreen(80, 24), themes.NewTheme("auto", nil), "")
+	var page strings.Builder
+	pt := pageText{out: &page}
+
+	ui.ipcConnectionsForPaging(picked, []*processes.Process{picked}, noSockets, pipes, &pt)
+
+	expected := "" +
+		"<Unable to list pipes: boom>\n" +
+		"<Detected: TCP, UDP. Not detected: unix sockets>\n" +
+		"<No connections found>\n"
+	assert.Equal(t, sectionBody(page.String()), expected)
+}
+
+func TestIpcConnectionsForPagingSocketListingFailed(t *testing.T) {
+	sockets := socketListing{err: errors.New("boom")}
+	pipes := pipeListing{byPid: map[int][]processes.PipeEnd{
+		42:   {{Fd: "1", Access: processes.PipeAccessWrite, Inode: "16466"}},
+		5678: {{Fd: "0", Access: processes.PipeAccessRead, Inode: "16466"}},
+	}}
+
+	picked := &processes.Process{Pid: 42, Cmdline: "picked"}
+	allProcesses := []*processes.Process{picked, {Pid: 5678, Cmdline: "sort"}}
+
+	ui := NewUi(twin.NewFakeScreen(80, 24), themes.NewTheme("auto", nil), "")
+	var page strings.Builder
+	pt := pageText{out: &page}
+
+	ui.ipcConnectionsForPaging(picked, allProcesses, sockets, pipes, &pt)
+
+	expected := "" +
+		"<Unable to list sockets: boom>\n" +
+		"<Detected: pipes. Not detected: unix sockets>\n" +
+		"picked(42) --> sort(5678)  pipe\n"
+	assert.Equal(t, sectionBody(page.String()), expected)
 }

--- a/internal/ftop/pageipcconnections_test.go
+++ b/internal/ftop/pageipcconnections_test.go
@@ -18,9 +18,10 @@ var noPipes = pipeListing{byPid: map[int][]processes.PipeEnd{}}
 var noSockets = socketListing{byPid: map[int][]processes.Socket{}}
 
 // Connections to other processes, one line each, with the arrows pointing from
-// whoever dialed to whoever was dialed — both ways for the UDP peer, since UDP says
-// nothing about who dialed whom. The listening socket on 8080 and the connection to
-// 1.2.3.4 belong in the Network Connections section and must not turn up here.
+// whoever dialed to whoever was dialed — a question mark for the UDP peer, since
+// UDP says nothing about who dialed whom. The listening socket on 8080 and the
+// connection to 1.2.3.4 belong in the Network Connections section and must not
+// turn up here.
 func TestIpcConnectionsForPagingListsProcessPeers(t *testing.T) {
 	sockets := socketListing{byPid: map[int][]processes.Socket{
 		42: {
@@ -56,7 +57,7 @@ func TestIpcConnectionsForPagingListsProcessPeers(t *testing.T) {
 		"<Detected: TCP, UDP, pipes. Not detected: unix sockets>\n" +
 		"curl(999) --> picked(42)                   tcp 8080\n" +
 		"              picked(42) --> sshd(1)       tcp 22\n" +
-		"              picked(42) <-> dnsmasq(777)  udp 53\n"
+		"              picked(42) <?> dnsmasq(777)  udp 53\n"
 	assert.Equal(t, sectionBody(page.String()), expected)
 
 	assert.Equal(t, stringsContains(page.String(), "──Inter Process Communication──"), true)
@@ -108,8 +109,8 @@ func TestIpcConnectionsForPagingListsPipes(t *testing.T) {
 	assert.Equal(t, sectionBody(page.String()), expected)
 }
 
-// macOS lsof won't say which end of a pipe writes, so there the arrow points
-// both ways, the way it does for UDP.
+// macOS lsof won't say which end of a pipe writes, so there a pipe gets a
+// question mark instead of an arrow, the way a UDP connection does.
 func TestIpcConnectionsForPagingPipeOfUnknownDirection(t *testing.T) {
 	pipes := pipeListing{byPid: map[int][]processes.PipeEnd{
 		42:   {{Fd: "1", Device: "0xaaaa", PeerDevice: "0xbbbb"}},
@@ -127,7 +128,7 @@ func TestIpcConnectionsForPagingPipeOfUnknownDirection(t *testing.T) {
 
 	expected := "" +
 		"<Detected: TCP, UDP, pipes. Not detected: unix sockets>\n" +
-		"picked(42) <-> sort(5678)  pipe\n"
+		"picked(42) <?> sort(5678)  pipe\n"
 	assert.Equal(t, sectionBody(page.String()), expected)
 }
 

--- a/internal/ftop/pageipcconnections_test.go
+++ b/internal/ftop/pageipcconnections_test.go
@@ -287,7 +287,7 @@ func TestIpcConnectionsForPagingPipeListingFailed(t *testing.T) {
 
 	expected := "" +
 		"<Unable to list pipes: boom>\n" +
-		"<Detected: TCP, UDP. Not detected: unix sockets>\n" +
+		"<Detected: TCP, UDP. Not detected: pipes, unix sockets>\n" +
 		"picked(42) --> sshd(1)  tcp 22\n"
 	assert.Equal(t, sectionBody(page.String()), expected)
 }
@@ -307,7 +307,7 @@ func TestIpcConnectionsForPagingPipeListingFailedAndNoSockets(t *testing.T) {
 
 	expected := "" +
 		"<Unable to list pipes: boom>\n" +
-		"<Detected: TCP, UDP. Not detected: unix sockets>\n" +
+		"<Detected: TCP, UDP. Not detected: pipes, unix sockets>\n" +
 		"<No connections found>\n"
 	assert.Equal(t, sectionBody(page.String()), expected)
 }
@@ -330,7 +330,7 @@ func TestIpcConnectionsForPagingSocketListingFailed(t *testing.T) {
 
 	expected := "" +
 		"<Unable to list sockets: boom>\n" +
-		"<Detected: pipes. Not detected: unix sockets>\n" +
+		"<Detected: pipes. Not detected: TCP, UDP, unix sockets>\n" +
 		"picked(42) --> sort(5678)  pipe\n"
 	assert.Equal(t, sectionBody(page.String()), expected)
 }

--- a/internal/ftop/pageloginhistory.go
+++ b/internal/ftop/pageloginhistory.go
@@ -5,6 +5,7 @@ import (
 	"github.com/walles/ftop/internal/processes"
 )
 
+// Seam for testing, see the ones in pageprocessinfo.go
 var getLoggedInUsersAt = loginhistory.GetUsersAt
 
 func (u *Ui) usersLoggedInWhenProcessStartedForPaging(proc *processes.Process, pt *pageText) {

--- a/internal/ftop/pagenetworkconnections.go
+++ b/internal/ftop/pagenetworkconnections.go
@@ -11,7 +11,9 @@ import (
 	"github.com/walles/ftop/internal/processes"
 )
 
-// Seam for testing, see resolveAddressesViaDns()
+// Seam for testing, see resolveAddressesViaDns(). This one is not only about
+// asserting on a known answer: without it every page test reaching this section
+// does real reverse DNS lookups.
 var resolveAddresses = resolveAddressesViaDns
 
 // The connections between this process and the rest of the world, plus the

--- a/internal/ftop/pagenetworkconnections_test.go
+++ b/internal/ftop/pagenetworkconnections_test.go
@@ -82,9 +82,9 @@ func TestNetworkConnectionsForPagingListsRemotePeers(t *testing.T) {
 	assert.Equal(t, stringsContains(page.String(), "──Network Connections──"), true)
 }
 
-// UDP says nothing about who dialed whom, so its lines get an arrow pointing both
-// ways. That arrow is as wide as the one way arrow, so a section holding both kinds
-// of line still lines up.
+// UDP says nothing about who dialed whom, so its lines get a question mark rather
+// than an arrow. That marker is as wide as the arrow, so a section holding both
+// kinds of line still lines up.
 func TestNetworkConnectionsForPagingUndeterminedDirection(t *testing.T) {
 	sockets := socketListing{byPid: map[int][]processes.Socket{
 		42: {
@@ -104,7 +104,7 @@ func TestNetworkConnectionsForPagingUndeterminedDirection(t *testing.T) {
 
 	expected := "" +
 		"picked(42) --> api.github.com  tcp 443\n" +
-		"picked(42) <-> dns.google      udp 53\n"
+		"picked(42) <?> dns.google      udp 53\n"
 	assert.Equal(t, sectionBody(page.String()), expected)
 }
 

--- a/internal/ftop/pageprocessinfo.go
+++ b/internal/ftop/pageprocessinfo.go
@@ -14,6 +14,9 @@ import (
 
 const DISPLAY_TIME_FORMAT = "2006-01-02 Mon 15:04:05MST"
 
+// Seams for testing. Every section that collects by forking a subprocess declares
+// its collector this way, so that a page test can hand it a listing and assert the
+// rendered result without an lsof on the machine having to contain one.
 var getSocketsByPid = processes.GetSocketsByPid
 var getPipeEndsByPid = processes.GetPipeEndsByPid
 

--- a/internal/ftop/pageprocessinfo.go
+++ b/internal/ftop/pageprocessinfo.go
@@ -15,6 +15,7 @@ import (
 const DISPLAY_TIME_FORMAT = "2006-01-02 Mon 15:04:05MST"
 
 var getSocketsByPid = processes.GetSocketsByPid
+var getPipeEndsByPid = processes.GetPipeEndsByPid
 
 // The TCP and UDP sockets of every process we were allowed to inspect, or the
 // error that came of trying to list them.
@@ -24,6 +25,17 @@ var getSocketsByPid = processes.GetSocketsByPid
 // their own error states, which is what the error is doing here.
 type socketListing struct {
 	byPid map[int][]processes.Socket
+	err   error
+}
+
+// The pipe ends of every process we were allowed to inspect, or the error that
+// came of trying to list them.
+//
+// A listing of its own rather than part of socketListing: it takes a second lsof
+// invocation, an unfiltered and slower one, and only the Inter Process
+// Communication section has any use for it.
+type pipeListing struct {
+	byPid map[int][]processes.PipeEnd
 	err   error
 }
 
@@ -117,6 +129,13 @@ func (u *Ui) writeProcessInfo(proc *processes.Process, allProcesses []*processes
 		return socketListing{byPid: byPid, err: err}
 	})
 
+	// Listed lazily as well, and separately: this is the unfiltered lsof, which
+	// costs about twice what the socket one does, and only one section wants it.
+	pipes := sync.OnceValue(func() pipeListing {
+		byPid, err := getPipeEndsByPid()
+		return pipeListing{byPid: byPid, err: err}
+	})
+
 	sections := []func(){
 		func() { u.commandLineForPaging(proc, &pt) },
 		func() { u.launchHierarchyForPaging(proc, &pt) },
@@ -124,7 +143,7 @@ func (u *Ui) writeProcessInfo(proc *processes.Process, allProcesses []*processes
 		func() { u.closeLaunchesForPaging(proc, &pt) },
 		func() { u.usersLoggedInWhenProcessStartedForPaging(proc, &pt) },
 		func() { u.cwdFriendsForPaging(proc, allProcesses, &pt) },
-		func() { u.ipcConnectionsForPaging(proc, allProcesses, sockets(), &pt) },
+		func() { u.ipcConnectionsForPaging(proc, allProcesses, sockets(), pipes(), &pt) },
 		func() { u.networkConnectionsForPaging(proc, allProcesses, sockets(), &pt) },
 	}
 

--- a/internal/ftop/pageprocessinfo_test.go
+++ b/internal/ftop/pageprocessinfo_test.go
@@ -33,12 +33,38 @@ func fakeSockets(t *testing.T, socketsByPid map[int][]processes.Socket, err erro
 	}
 }
 
+// Replaces the lsof pipe lookup for the duration of the test. The returned
+// function tells how many times it has been called.
+//
+// Every test composing a whole page needs this: the pipe listing is the
+// unfiltered lsof, so without it the test forks one and parses every open file
+// on the machine.
+func fakePipes(t *testing.T, pipeEndsByPid map[int][]processes.PipeEnd, err error) func() int {
+	t.Helper()
+
+	original := getPipeEndsByPid
+	t.Cleanup(func() {
+		getPipeEndsByPid = original
+	})
+
+	calls := 0
+	getPipeEndsByPid = func() (map[int][]processes.PipeEnd, error) {
+		calls++
+		return pipeEndsByPid, err
+	}
+
+	return func() int {
+		return calls
+	}
+}
+
 // Both connection sections render from one and the same socket listing, so that
 // they can't disagree about a connection that came or went in between two lsof
 // runs.
 func TestWriteProcessInfoListsSocketsOnce(t *testing.T) {
 	fakeCwds(t, map[int]string{42: "/Users/johan/src/ftop"}, nil)
 	socketCalls := fakeSockets(t, map[int][]processes.Socket{}, nil)
+	fakePipes(t, map[int][]processes.PipeEnd{}, nil)
 	fakeDns(t, nil)
 
 	original := getLoggedInUsersAt
@@ -63,6 +89,7 @@ func TestWriteProcessInfoListsSocketsOnce(t *testing.T) {
 func TestWriteProcessInfoSeparatesSections(t *testing.T) {
 	fakeCwds(t, map[int]string{42: "/Users/johan/src/ftop"}, nil)
 	fakeSockets(t, map[int][]processes.Socket{}, nil)
+	fakePipes(t, map[int][]processes.PipeEnd{}, nil)
 	fakeDns(t, nil)
 
 	original := getLoggedInUsersAt

--- a/internal/ftop/pagetext_test.go
+++ b/internal/ftop/pagetext_test.go
@@ -49,6 +49,13 @@ func stripAnsi(styled string) string {
 //
 // Section titles end in a blank line and nothing else in a section does, so the
 // first one is where the title ends and the body begins.
+//
+// Compare this against a complete expected block rather than picking fragments
+// out of it with stringsContains(): alignment is a feature of these sections, and
+// asserting "sshd(123)" passes whether or not the columns line up. An expected
+// block doubles as documentation of what a section looks like, which is why the
+// mockups the design notes used to carry are now these strings. stringsContains()
+// is for error and empty states, where there is no layout to get wrong.
 func sectionBody(page string) string {
 	_, body, _ := strings.Cut(stripAnsi(page), "\n\n")
 	return body

--- a/internal/processes/networkconnections.go
+++ b/internal/processes/networkconnections.go
@@ -25,7 +25,7 @@ type Peer struct {
 // the other, worked out from the ports this machine listens on, so it can come
 // out backwards for a connection whose listening socket we cannot see; see
 // directionAndPort(). For a pipe it is which way the data flows, read off the
-// access mode of the end we hold; see pipeDirection().
+// access modes of the ends we hold; see pipeDirection().
 type Direction int
 
 const (

--- a/internal/processes/networkconnections.go
+++ b/internal/processes/networkconnections.go
@@ -41,6 +41,17 @@ const (
 	DirectionUnknown
 )
 
+// What a connection is carried by, lowercased so that it can go straight into
+// the page. A transport protocol for a socket, and the kind of thing it is for
+// everything else.
+type Protocol string
+
+const (
+	ProtocolTcp  Protocol = "tcp"
+	ProtocolUdp  Protocol = "udp"
+	ProtocolPipe Protocol = "pipe"
+)
+
 // Some number of connections between one process and one peer, all of them
 // speaking the same protocol to or from the same port.
 type Connection struct {

--- a/internal/processes/networkconnections.go
+++ b/internal/processes/networkconnections.go
@@ -19,21 +19,25 @@ type Peer struct {
 	Pid int
 }
 
-// Which end dialed the other.
+// Which way a connection's arrow points.
 //
-// Worked out from the ports this machine listens on, so it can come out
-// backwards for a connection whose listening socket we cannot see, and UDP has
-// no equivalent to compare against at all. See directionAndPort().
+// Two different facts share the one arrow. For a socket it is which end dialed
+// the other, worked out from the ports this machine listens on, so it can come
+// out backwards for a connection whose listening socket we cannot see; see
+// directionAndPort(). For a pipe it is which way the data flows, read off the
+// access mode of the end we hold; see pipeDirection().
 type Direction int
 
 const (
-	// The peer dialed us
+	// The peer dialed us, or writes into a pipe we read
 	DirectionIncoming Direction = iota
 
-	// We dialed the peer
+	// We dialed the peer, or write into a pipe they read
 	DirectionOutgoing
 
-	// No telling which end dialed the other. Every UDP connection is this.
+	// No telling. Every UDP connection is this, UDP having no listening state
+	// to compare a port against, and so is every anonymous pipe on macOS, whose
+	// lsof reports no access mode for one.
 	DirectionUnknown
 )
 
@@ -156,9 +160,18 @@ func NetworkConnections(proc *Process, allProcesses []*Process, socketsByPid map
 		connections = append(connections, connection)
 	}
 
-	slices.SortFunc(connections, compareConnections)
+	SortConnections(connections)
 
 	return connections
+}
+
+// Sorts connections into display order, in place.
+//
+// Exported because a page section showing more than one kind of connection has
+// to merge the lists and sort the result, see compareConnections() for what the
+// order is.
+func SortConnections(connections []Connection) {
+	slices.SortFunc(connections, compareConnections)
 }
 
 // Which end of socket dialed the other, and the port worth reporting it on.
@@ -409,15 +422,19 @@ func splitEndpoint(endpoint string) (address string, port int) {
 
 // Listening ports first, then incoming connections, then outgoing ones, then the
 // ones nobody can tell the direction of, so that each way of drawing a connection
-// stays in one block of the listing. Then by peer name, peer PID and port, all of
-// which are only tie breakers, there to make the order the same every time.
+// stays in one block of the listing. Protocol next, so that a block of pipes and
+// a block of sockets don't interleave, their descriptions being the column a
+// reader scans. Then by peer name, peer PID and port, all of which are only tie
+// breakers, there to make the order the same every time.
 //
-// Protocol is not among the keys, and doesn't need to be: TCP is the only
-// protocol that ever lands in the first three groups and UDP the only one that
-// lands in the last, so the blocks come out protocol-pure anyway.
+// Sorting by protocol used to be unnecessary, TCP being the only protocol
+// reaching the first three groups and UDP the only one reaching the last, which
+// made the blocks protocol-pure for free. Pipes reach both the incoming and the
+// outgoing group and ended that.
 func compareConnections(a Connection, b Connection) int {
 	return cmp.Or(
 		cmp.Compare(sortGroup(a), sortGroup(b)),
+		strings.Compare(string(a.Protocol), string(b.Protocol)),
 		strings.Compare(a.Peer.Name, b.Peer.Name),
 		cmp.Compare(a.Peer.Pid, b.Peer.Pid),
 		cmp.Compare(a.Port, b.Port),

--- a/internal/processes/networkconnections.go
+++ b/internal/processes/networkconnections.go
@@ -51,6 +51,9 @@ type Connection struct {
 	// The port being served, never the ephemeral one the client picked. The
 	// peer's port when Direction is DirectionUnknown, there being no telling
 	// which of the two is the served one.
+	//
+	// Zero for a connection carried by something that has no ports at all, a
+	// pipe being one, and then rendered as the bare protocol.
 	Port int
 
 	// True for a port we accept connections on. Such a connection has no peer,

--- a/internal/processes/networkconnections_test.go
+++ b/internal/processes/networkconnections_test.go
@@ -557,3 +557,46 @@ func TestNetworkConnections_noSocketsOfOurOwn(t *testing.T) {
 
 	assert.Equal(t, len(connections), 0)
 }
+
+// A section showing more than one kind of connection sorts them together, and
+// the protocols must not interleave: the description column is what a reader
+// scans, and a block of pipes broken up by a socket line reads as noise.
+//
+// The peer names here are chosen so that sorting by name alone would interleave
+// them, which is what makes this test say anything.
+func TestSortConnections_keepsProtocolsApart(t *testing.T) {
+	connections := []Connection{
+		{Peer: Peer{Name: "alpha", Pid: 1}, Protocol: ProtocolTcp, Direction: DirectionOutgoing, Port: 443, Count: 1},
+		{Peer: Peer{Name: "beta", Pid: 2}, Protocol: ProtocolPipe, Direction: DirectionOutgoing, Count: 1},
+		{Peer: Peer{Name: "gamma", Pid: 3}, Protocol: ProtocolTcp, Direction: DirectionOutgoing, Port: 22, Count: 1},
+		{Peer: Peer{Name: "delta", Pid: 4}, Protocol: ProtocolPipe, Direction: DirectionOutgoing, Count: 1},
+	}
+
+	SortConnections(connections)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "beta", Pid: 2}, Protocol: ProtocolPipe, Direction: DirectionOutgoing, Count: 1},
+		{Peer: Peer{Name: "delta", Pid: 4}, Protocol: ProtocolPipe, Direction: DirectionOutgoing, Count: 1},
+		{Peer: Peer{Name: "alpha", Pid: 1}, Protocol: ProtocolTcp, Direction: DirectionOutgoing, Port: 443, Count: 1},
+		{Peer: Peer{Name: "gamma", Pid: 3}, Protocol: ProtocolTcp, Direction: DirectionOutgoing, Port: 22, Count: 1},
+	})
+}
+
+// Which way a connection is drawn decides its block, and that outranks the
+// protocol: an incoming pipe belongs with the incoming sockets rather than with
+// the outgoing pipes.
+func TestSortConnections_directionOutranksProtocol(t *testing.T) {
+	connections := []Connection{
+		{Peer: Peer{Name: "alpha", Pid: 1}, Protocol: ProtocolPipe, Direction: DirectionOutgoing, Count: 1},
+		{Peer: Peer{Name: "beta", Pid: 2}, Protocol: ProtocolTcp, Direction: DirectionIncoming, Port: 8080, Count: 1},
+		{Peer: Peer{Name: "gamma", Pid: 3}, Protocol: ProtocolPipe, Direction: DirectionIncoming, Count: 1},
+	}
+
+	SortConnections(connections)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "gamma", Pid: 3}, Protocol: ProtocolPipe, Direction: DirectionIncoming, Count: 1},
+		{Peer: Peer{Name: "beta", Pid: 2}, Protocol: ProtocolTcp, Direction: DirectionIncoming, Port: 8080, Count: 1},
+		{Peer: Peer{Name: "alpha", Pid: 1}, Protocol: ProtocolPipe, Direction: DirectionOutgoing, Count: 1},
+	})
+}

--- a/internal/processes/pipeconnections.go
+++ b/internal/processes/pipeconnections.go
@@ -22,13 +22,7 @@ package processes
 //
 // Count is how many distinct pipes a line stands for, so two processes at the
 // ends of one pipe report a count of 1 however many file descriptors either of
-// them has it open on.
-//
-// Known limit: two ends of one pipe held by us can disagree about its direction,
-// an end open for reading and writing both being DirectionUnknown where a plain
-// write end of the same pipe is DirectionOutgoing. Direction is part of what
-// identifies a line, so such a pipe draws two lines to the one peer rather than
-// one. It takes "exec 3>fifo 4<>fifo" to construct.
+// them has it open on, and however many of its ends either of them holds.
 func PipeConnections(proc *Process, allProcesses []*Process, pipeEndsByPid map[int][]PipeEnd) []Connection {
 	if len(pipeEndsByPid[proc.Pid]) == 0 {
 		return nil
@@ -49,12 +43,17 @@ func PipeConnections(proc *Process, allProcesses []*Process, pipeEndsByPid map[i
 		names[candidate.Pid] = candidate.Command()
 	}
 
-	// The connections we found, mapped to the pipes carrying each of them. A set
-	// rather than a counter because one pipe can match several of a peer's ends,
-	// a process holding a FIFO for reading and for writing both being enough,
-	// and that is still one pipe. The keys carry no Count of their own, that is
-	// what the values are for.
-	pipes := map[Connection]map[string]bool{}
+	// One entry per pipe we share with a peer, holding what our own ends of that
+	// pipe let us do with it. Keyed by peer and pipe rather than by the Connection
+	// the end produces, so that several of our own ends of one pipe make one line:
+	// they can disagree about direction, an end open for reading and writing both
+	// saying nothing where a write end of that very pipe says outgoing, and the
+	// pipe is one pipe regardless.
+	//
+	// One pipe can also match several of the peer's ends, a process holding a FIFO
+	// for reading and for writing both being enough, and this collapses that as
+	// well.
+	usages := map[peerPipe]pipeUsage{}
 
 	for _, ourEnd := range ourEnds {
 		for peerPid, theirEnds := range endsByPid {
@@ -67,30 +66,56 @@ func PipeConnections(proc *Process, allProcesses []*Process, pipeEndsByPid map[i
 					continue
 				}
 
-				connection := Connection{
-					Peer:      Peer{Name: names[peerPid], Pid: peerPid},
-					Protocol:  ProtocolPipe,
-					Direction: pipeDirection(ourEnd),
-				}
+				key := peerPipe{peerPid: peerPid, pipe: pipeIdentity(ourEnd)}
 
-				if pipes[connection] == nil {
-					pipes[connection] = map[string]bool{}
-				}
-
-				pipes[connection][pipeIdentity(ourEnd)] = true
+				usage := usages[key]
+				usage.canWrite = usage.canWrite || canWrite(ourEnd)
+				usage.canRead = usage.canRead || canRead(ourEnd)
+				usages[key] = usage
 			}
 		}
 	}
 
-	connections := make([]Connection, 0, len(pipes))
-	for connection, carriedBy := range pipes {
-		connection.Count = len(carriedBy)
+	// How many pipes each line stands for. Two pipes to one peer that we use the
+	// same way are one line counting two; used opposite ways they are two lines.
+	pipeCounts := map[Connection]int{}
+	for key, usage := range usages {
+		connection := Connection{
+			Peer:      Peer{Name: names[key.peerPid], Pid: key.peerPid},
+			Protocol:  ProtocolPipe,
+			Direction: pipeDirection(usage),
+		}
+
+		pipeCounts[connection]++
+	}
+
+	connections := make([]Connection, 0, len(pipeCounts))
+	for connection, count := range pipeCounts {
+		connection.Count = count
 		connections = append(connections, connection)
 	}
 
 	SortConnections(connections)
 
 	return connections
+}
+
+// One pipe shared with one process, which is what a line stands for before the
+// lines to a peer are aggregated into one.
+type peerPipe struct {
+	peerPid int
+
+	// pipeIdentity() of the pipe
+	pipe string
+}
+
+// What our own ends of one pipe, taken together, let us do with it.
+//
+// Both false for a pipe lsof reports no access mode for, which is every anonymous
+// pipe on macOS.
+type pipeUsage struct {
+	canWrite bool
+	canRead  bool
 }
 
 // True if ours and theirs are two ends of one and the same pipe, so that what is
@@ -107,24 +132,26 @@ func PipeConnections(proc *Process, allProcesses []*Process, pipeEndsByPid map[i
 // device of its own — the file system it lives on, which is how Linux reports
 // one — so Device being set says nothing about which clause applies.
 //
-// The inode way needs the access modes as well, since every end of a pipe shares
-// its inode and two processes writing into one pipe are not talking to each
-// other. The device way needs no such thing, an end named that way pointing at
-// exactly one other end.
+// The inode way needs the file system device as well, two named FIFOs on
+// different file systems being free to share an inode number — a FIFO on each of
+// two fresh tmpfs mounts is inode 2 on both. And it needs the access modes, since
+// every end of a pipe shares its inode and two processes writing into one pipe are
+// not talking to each other. The device way needs neither, an end named that way
+// pointing at exactly one other end.
 //
 // This is no check that the two ends are distinct: an end open for reading and
 // writing both satisfies it against itself. A caller walking one process' own
 // ends has to exclude that, which PipeConnections() does via isTheReportingEnd().
-//
-// Known limit: two named FIFOs on different file systems can share an inode
-// number, and this would call their ends a pair. Telling them apart means
-// comparing the device as well, which macOS reports for no FIFO at all.
 func arePipeEnds(ours PipeEnd, theirs PipeEnd) bool {
 	if ours.PeerDevice != "" && ours.PeerDevice == theirs.Device {
 		return true
 	}
 
 	if ours.Inode == "" || ours.Inode != theirs.Inode {
+		return false
+	}
+
+	if ours.FileSystemDevice != theirs.FileSystemDevice {
 		return false
 	}
 
@@ -135,22 +162,22 @@ func arePipeEnds(ours PipeEnd, theirs PipeEnd) bool {
 	return canWrite(ours) && canRead(theirs) || canRead(ours) && canWrite(theirs)
 }
 
-// Which way the data goes through the end we hold: out of us when we write into
-// it, into us when we read from it.
+// Which way the data goes through the ends we hold of one pipe: out of us if all
+// they let us do is write into it, into us if all they let us do is read it.
 //
-// DirectionUnknown for an end that can go either way, and for one lsof names no
-// mode for, which is every anonymous pipe on macOS.
-func pipeDirection(end PipeEnd) Direction {
-	switch end.Access {
-	case PipeAccessWrite:
+// DirectionUnknown where they let us do both, since then an arrow either way is a
+// claim the other direction contradicts, and where they let us do neither, which
+// is what lsof naming no access mode comes to.
+func pipeDirection(usage pipeUsage) Direction {
+	if usage.canWrite && !usage.canRead {
 		return DirectionOutgoing
-
-	case PipeAccessRead:
-		return DirectionIncoming
-
-	default:
-		return DirectionUnknown
 	}
+
+	if usage.canRead && !usage.canWrite {
+		return DirectionIncoming
+	}
+
+	return DirectionUnknown
 }
 
 // True if ours is the end to report a pipe by, where both of its ends are held
@@ -183,17 +210,15 @@ func canRead(end PipeEnd) bool {
 // What identifies the pipe an end belongs to, for telling several pipes to one
 // peer apart from one pipe that matched several of its ends.
 //
-// The inode where there is one, that being the pipe itself. Where there isn't,
-// which is macOS for an anonymous pipe, the kernel addresses of the pipe's two
-// ends name it just as well, sorted so that either end spells it the same way.
-//
-// Known limit, the same one arePipeEnds() has: two named FIFOs on different file
-// systems sharing an inode number come out as one pipe here, so a peer at the
-// end of both gets a Count of 1 rather than 2. Closing it means keying on the
-// device as well.
+// The inode plus the file system it lives on where there is one, that pair being
+// the pipe itself — the inode alone would make one pipe of two FIFOs that share an
+// inode number on different file systems, and a peer at the end of both would get
+// a Count of 1 where it earned 2. Where there is no inode, which is macOS for an
+// anonymous pipe, the kernel addresses of the pipe's two ends name it just as
+// well, sorted so that either end spells it the same way.
 func pipeIdentity(end PipeEnd) string {
 	if end.Inode != "" {
-		return "inode " + end.Inode
+		return "inode " + end.FileSystemDevice + " " + end.Inode
 	}
 
 	return "devices " + min(end.Device, end.PeerDevice) + " " + max(end.Device, end.PeerDevice)
@@ -225,6 +250,12 @@ func deduplicatePipeEnds(ends []PipeEnd) []PipeEnd {
 
 // Everything about a pipe end except which file descriptor it arrived on, in a
 // form that can be compared and ordered.
+//
+// The file system device is part of it for the same reason arePipeEnds() compares
+// it: without it, two ends of two FIFOs that share an inode number are spelled
+// identically, and deduplicatePipeEnds() would throw one of them away before
+// anything got the chance to match it.
 func pipeEndIdentity(end PipeEnd) string {
-	return string(end.Access) + "\x00" + end.Device + "\x00" + end.PeerDevice + "\x00" + end.Inode
+	return string(end.Access) + "\x00" + end.Device + "\x00" + end.PeerDevice +
+		"\x00" + end.FileSystemDevice + "\x00" + end.Inode
 }

--- a/internal/processes/pipeconnections.go
+++ b/internal/processes/pipeconnections.go
@@ -1,0 +1,19 @@
+package processes
+
+// The pipes proc holds an end of, aggregated and sorted for display.
+//
+// pipeEndsByPid is every pipe end we could see, see GetPipeEndsByPid(); the ends
+// held by other processes are what lets us name the process at the other end of
+// a pipe. allProcesses turns those PIDs into names; pass every process you know
+// about. A peer we find no process for keeps its PID and gets no name.
+//
+// Pipe ends we find no peer for are left out. The peer may be a process we
+// aren't allowed to inspect, or the pipe may have nobody at the other end at
+// all, and there is no telling those apart.
+//
+// Every connection comes back with Protocol ProtocolPipe and Port 0, a pipe
+// having no port.
+func PipeConnections(proc *Process, allProcesses []*Process, pipeEndsByPid map[int][]PipeEnd) []Connection {
+	// TODO: Implement
+	return nil
+}

--- a/internal/processes/pipeconnections.go
+++ b/internal/processes/pipeconnections.go
@@ -13,7 +13,218 @@ package processes
 //
 // Every connection comes back with Protocol ProtocolPipe and Port 0, a pipe
 // having no port.
+//
+// Unlike a socket, a pipe has as many ends as anybody cares to fork, so every
+// peer holding one gets a line of its own: three processes reading what we write
+// are three processes we are talking to. A process holding both ends of a pipe
+// is the one exception, that being one pipe and so one line, see
+// isTheReportingEnd().
+//
+// Count is how many distinct pipes a line stands for, so two processes at the
+// ends of one pipe report a count of 1 however many file descriptors either of
+// them has it open on.
+//
+// Known limit: two ends of one pipe held by us can disagree about its direction,
+// an end open for reading and writing both being DirectionUnknown where a plain
+// write end of the same pipe is DirectionOutgoing. Direction is part of what
+// identifies a line, so such a pipe draws two lines to the one peer rather than
+// one. It takes "exec 3>fifo 4<>fifo" to construct.
 func PipeConnections(proc *Process, allProcesses []*Process, pipeEndsByPid map[int][]PipeEnd) []Connection {
-	// TODO: Implement
-	return nil
+	if len(pipeEndsByPid[proc.Pid]) == 0 {
+		return nil
+	}
+
+	// Deduplicated up front rather than inside the loop below, which would walk
+	// the whole machine's pipe ends again for every end we hold ourselves. That
+	// is thousands of ends times dozens of our own on the busy box this is for.
+	endsByPid := make(map[int][]PipeEnd, len(pipeEndsByPid))
+	for pid, ends := range pipeEndsByPid {
+		endsByPid[pid] = deduplicatePipeEnds(ends)
+	}
+
+	ourEnds := endsByPid[proc.Pid]
+
+	names := map[int]string{}
+	for _, candidate := range allProcesses {
+		names[candidate.Pid] = candidate.Command()
+	}
+
+	// The connections we found, mapped to the pipes carrying each of them. A set
+	// rather than a counter because one pipe can match several of a peer's ends,
+	// a process holding a FIFO for reading and for writing both being enough,
+	// and that is still one pipe. The keys carry no Count of their own, that is
+	// what the values are for.
+	pipes := map[Connection]map[string]bool{}
+
+	for _, ourEnd := range ourEnds {
+		for peerPid, theirEnds := range endsByPid {
+			for _, theirEnd := range theirEnds {
+				if !arePipeEnds(ourEnd, theirEnd) {
+					continue
+				}
+
+				if peerPid == proc.Pid && !isTheReportingEnd(ourEnd, theirEnd) {
+					continue
+				}
+
+				connection := Connection{
+					Peer:      Peer{Name: names[peerPid], Pid: peerPid},
+					Protocol:  ProtocolPipe,
+					Direction: pipeDirection(ourEnd),
+				}
+
+				if pipes[connection] == nil {
+					pipes[connection] = map[string]bool{}
+				}
+
+				pipes[connection][pipeIdentity(ourEnd)] = true
+			}
+		}
+	}
+
+	connections := make([]Connection, 0, len(pipes))
+	for connection, carriedBy := range pipes {
+		connection.Count = len(carriedBy)
+		connections = append(connections, connection)
+	}
+
+	SortConnections(connections)
+
+	return connections
+}
+
+// True if ours and theirs are two ends of one and the same pipe, so that what is
+// written into one can be read out of the other.
+//
+// Two mechanisms in one predicate, needing no GOOS switch because only one of
+// them can fire for any given end. The device clause tests PeerDevice, which is
+// populated from an "n->0x..." name and nothing else, and only macOS names an
+// anonymous pipe end that way; Linux calls every anonymous pipe the literal
+// string "pipe" and identifies it by its inode instead. A named FIFO carries an
+// inode on both platforms and goes the inode way.
+//
+// PeerDevice rather than Device is what carries that argument. A FIFO can have a
+// device of its own — the file system it lives on, which is how Linux reports
+// one — so Device being set says nothing about which clause applies.
+//
+// The inode way needs the access modes as well, since every end of a pipe shares
+// its inode and two processes writing into one pipe are not talking to each
+// other. The device way needs no such thing, an end named that way pointing at
+// exactly one other end.
+//
+// This is no check that the two ends are distinct: an end open for reading and
+// writing both satisfies it against itself. A caller walking one process' own
+// ends has to exclude that, which PipeConnections() does via isTheReportingEnd().
+//
+// Known limit: two named FIFOs on different file systems can share an inode
+// number, and this would call their ends a pair. Telling them apart means
+// comparing the device as well, which macOS reports for no FIFO at all.
+func arePipeEnds(ours PipeEnd, theirs PipeEnd) bool {
+	if ours.PeerDevice != "" && ours.PeerDevice == theirs.Device {
+		return true
+	}
+
+	if ours.Inode == "" || ours.Inode != theirs.Inode {
+		return false
+	}
+
+	// An end that can write pairs with an end that can read, which makes an end
+	// open for both a peer of readers, writers and other such ends alike. An end
+	// lsof reports no mode for can do neither as far as we know, and pairs with
+	// nothing.
+	return canWrite(ours) && canRead(theirs) || canRead(ours) && canWrite(theirs)
+}
+
+// Which way the data goes through the end we hold: out of us when we write into
+// it, into us when we read from it.
+//
+// DirectionUnknown for an end that can go either way, and for one lsof names no
+// mode for, which is every anonymous pipe on macOS.
+func pipeDirection(end PipeEnd) Direction {
+	switch end.Access {
+	case PipeAccessWrite:
+		return DirectionOutgoing
+
+	case PipeAccessRead:
+		return DirectionIncoming
+
+	default:
+		return DirectionUnknown
+	}
+}
+
+// True if ours is the end to report a pipe by, where both of its ends are held
+// by the process we are reporting on.
+//
+// Such a pipe is one pipe and deserves one line, so one of the two ends has to
+// stand for it. The writing one does, data flowing from there, and where lsof
+// won't say which end writes it goes by whichever end sorts first: arbitrary,
+// but the same end every time the page is opened.
+//
+// False for an end against itself, which is also what keeps a lone end open for
+// reading and writing both out of the listing as its own peer: arePipeEnds()
+// says such an end pairs with itself, and this is where that gets dropped.
+func isTheReportingEnd(ours PipeEnd, theirs PipeEnd) bool {
+	if canWrite(ours) != canWrite(theirs) {
+		return canWrite(ours)
+	}
+
+	return pipeEndIdentity(ours) < pipeEndIdentity(theirs)
+}
+
+func canWrite(end PipeEnd) bool {
+	return end.Access == PipeAccessWrite || end.Access == PipeAccessReadWrite
+}
+
+func canRead(end PipeEnd) bool {
+	return end.Access == PipeAccessRead || end.Access == PipeAccessReadWrite
+}
+
+// What identifies the pipe an end belongs to, for telling several pipes to one
+// peer apart from one pipe that matched several of its ends.
+//
+// The inode where there is one, that being the pipe itself. Where there isn't,
+// which is macOS for an anonymous pipe, the kernel addresses of the pipe's two
+// ends name it just as well, sorted so that either end spells it the same way.
+//
+// Known limit, the same one arePipeEnds() has: two named FIFOs on different file
+// systems sharing an inode number come out as one pipe here, so a peer at the
+// end of both gets a Count of 1 rather than 2. Closing it means keying on the
+// device as well.
+func pipeIdentity(end PipeEnd) string {
+	if end.Inode != "" {
+		return "inode " + end.Inode
+	}
+
+	return "devices " + min(end.Device, end.PeerDevice) + " " + max(end.Device, end.PeerDevice)
+}
+
+// A process' pipe ends with the repeats left out, recognized by what they are
+// rather than by the descriptor they arrived on.
+//
+// One end open on several file descriptors, by dup(2) or by being inherited as
+// both stdout and stderr, is reported once per descriptor, and counting those
+// would report one pipe as several. What is left is how lsof names the end plus
+// how it is open, which is everything about it that isn't the descriptor.
+func deduplicatePipeEnds(ends []PipeEnd) []PipeEnd {
+	seen := map[string]bool{}
+
+	var deduplicated []PipeEnd
+	for _, end := range ends {
+		identity := pipeEndIdentity(end)
+		if seen[identity] {
+			continue
+		}
+
+		seen[identity] = true
+		deduplicated = append(deduplicated, end)
+	}
+
+	return deduplicated
+}
+
+// Everything about a pipe end except which file descriptor it arrived on, in a
+// form that can be compared and ordered.
+func pipeEndIdentity(end PipeEnd) string {
+	return string(end.Access) + "\x00" + end.Device + "\x00" + end.PeerDevice + "\x00" + end.Inode
 }

--- a/internal/processes/pipeconnections.go
+++ b/internal/processes/pipeconnections.go
@@ -124,13 +124,14 @@ type pipeUsage struct {
 // Two mechanisms in one predicate, needing no GOOS switch because only one of
 // them can fire for any given end. The device clause tests PeerDevice, which is
 // populated from an "n->0x..." name and nothing else, and only macOS names an
-// anonymous pipe end that way; Linux calls every anonymous pipe the literal
-// string "pipe" and identifies it by its inode instead. A named FIFO carries an
-// inode on both platforms and goes the inode way.
+// anonymous pipe end that way. Such an end carries no inode, so it cannot reach
+// the inode clause; every other end can, Linux identifying an anonymous pipe by
+// its inode and a named FIFO carrying one on both platforms.
 //
-// PeerDevice rather than Device is what carries that argument. A FIFO can have a
-// device of its own — the file system it lives on, which is how Linux reports
-// one — so Device being set says nothing about which clause applies.
+// Testing PeerDevice rather than Device is not only about which platform reported
+// the end, which either field would settle. A macOS pipe keeps its Device once its
+// peer is gone, and then there is no other end left to name and nothing here for
+// it to match.
 //
 // The inode way needs the file system device as well, two named FIFOs on
 // different file systems being free to share an inode number — a FIFO on each of

--- a/internal/processes/pipeconnections_test.go
+++ b/internal/processes/pipeconnections_test.go
@@ -223,7 +223,7 @@ func TestPipeConnections_severalWriters(t *testing.T) {
 // An end opened for reading and writing both, which is what "exec 3<>fifo"
 // gets you, can send to a reader as well as any writer can.
 //
-// Which way the data goes it can't say, so the arrow points both ways.
+// Which way the data goes it can't say, so it gets no arrow.
 func TestPipeConnections_readWriteEndPairsWithAReader(t *testing.T) {
 	me := &Process{Pid: 1234, Cmdline: "shell"}
 	peer := &Process{Pid: 5678, Cmdline: "consumer"}

--- a/internal/processes/pipeconnections_test.go
+++ b/internal/processes/pipeconnections_test.go
@@ -1,0 +1,389 @@
+package processes
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/walles/ftop/internal/assert"
+)
+
+// macOS names each end of a pipe by its peer's kernel address, and that address
+// is what the peer's device field says. Which end writes it won't say, so
+// neither can we.
+func TestPipeConnections_macOsPair(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "grep"}
+	peer := &Process{Pid: 5678, Cmdline: "sort"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {{Fd: "1", Device: "0xaaaa", PeerDevice: "0xbbbb"}},
+		5678: {{Fd: "0", Device: "0xbbbb", PeerDevice: "0xaaaa"}},
+	}
+
+	connections := PipeConnections(me, []*Process{me, peer}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "sort", Pid: 5678}, Protocol: ProtocolPipe, Direction: DirectionUnknown, Count: 1},
+	})
+}
+
+// Linux names both ends of a pipe by the pipe's inode and tells them apart by
+// their access modes. Data flows from the writer to the reader, so the writing
+// end is the outgoing one.
+func TestPipeConnections_linuxWriteEnd(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "grep"}
+	peer := &Process{Pid: 5678, Cmdline: "sort"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {{Fd: "1", Access: PipeAccessWrite, Inode: "16466"}},
+		5678: {{Fd: "0", Access: PipeAccessRead, Inode: "16466"}},
+	}
+
+	connections := PipeConnections(me, []*Process{me, peer}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "sort", Pid: 5678}, Protocol: ProtocolPipe, Direction: DirectionOutgoing, Count: 1},
+	})
+}
+
+// The reading end of the same pipe, seen from the other process: the same pipe,
+// pointing the other way.
+func TestPipeConnections_linuxReadEnd(t *testing.T) {
+	writer := &Process{Pid: 1234, Cmdline: "grep"}
+	me := &Process{Pid: 5678, Cmdline: "sort"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {{Fd: "1", Access: PipeAccessWrite, Inode: "16466"}},
+		5678: {{Fd: "0", Access: PipeAccessRead, Inode: "16466"}},
+	}
+
+	connections := PipeConnections(me, []*Process{writer, me}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "grep", Pid: 1234}, Protocol: ProtocolPipe, Direction: DirectionIncoming, Count: 1},
+	})
+}
+
+// A named FIFO is matched the way a Linux pipe is, by inode and opposing access
+// modes, on either platform.
+func TestPipeConnections_namedFifo(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "producer"}
+	peer := &Process{Pid: 5678, Cmdline: "consumer"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {{Fd: "3", Access: PipeAccessWrite, Inode: "82144503"}},
+		5678: {{Fd: "3", Access: PipeAccessRead, Inode: "82144503"}},
+	}
+
+	connections := PipeConnections(me, []*Process{me, peer}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "consumer", Pid: 5678}, Protocol: ProtocolPipe, Direction: DirectionOutgoing, Count: 1},
+	})
+}
+
+// Two processes writing into one pipe are not talking to each other, however
+// much inode they have in common. Only opposing access modes make a pair.
+func TestPipeConnections_twoWritersAreNotPeers(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "grep"}
+	fellowWriter := &Process{Pid: 1235, Cmdline: "sed"}
+	reader := &Process{Pid: 5678, Cmdline: "sort"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {{Fd: "1", Access: PipeAccessWrite, Inode: "16466"}},
+		1235: {{Fd: "1", Access: PipeAccessWrite, Inode: "16466"}},
+		5678: {{Fd: "0", Access: PipeAccessRead, Inode: "16466"}},
+	}
+
+	connections := PipeConnections(me, []*Process{me, fellowWriter, reader}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "sort", Pid: 5678}, Protocol: ProtocolPipe, Direction: DirectionOutgoing, Count: 1},
+	})
+}
+
+// One pipe end open on several file descriptors, by dup(2) or by being inherited
+// as both stdout and stderr, is one pipe end. Counting the descriptors would
+// report one pipe as several.
+func TestPipeConnections_duplicatedDescriptors(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "grep"}
+	peer := &Process{Pid: 5678, Cmdline: "sort"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {
+			{Fd: "1", Access: PipeAccessWrite, Inode: "16466"},
+			{Fd: "2", Access: PipeAccessWrite, Inode: "16466"},
+		},
+		5678: {
+			{Fd: "0", Access: PipeAccessRead, Inode: "16466"},
+			{Fd: "3", Access: PipeAccessRead, Inode: "16466"},
+		},
+	}
+
+	connections := PipeConnections(me, []*Process{me, peer}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "sort", Pid: 5678}, Protocol: ProtocolPipe, Direction: DirectionOutgoing, Count: 1},
+	})
+}
+
+// The same pipe end on two descriptors, the way macOS spells it: one device,
+// and one pipe. The Linux sibling of this test tells the ends apart by their
+// access modes, which macOS doesn't report, so what identifies an end here is
+// its device alone.
+func TestPipeConnections_duplicatedDescriptorsOnMacOs(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "grep"}
+	peer := &Process{Pid: 5678, Cmdline: "sort"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {
+			{Fd: "1", Device: "0xaaaa", PeerDevice: "0xbbbb"},
+			{Fd: "2", Device: "0xaaaa", PeerDevice: "0xbbbb"},
+		},
+		5678: {
+			{Fd: "0", Device: "0xbbbb", PeerDevice: "0xaaaa"},
+			{Fd: "3", Device: "0xbbbb", PeerDevice: "0xaaaa"},
+		},
+	}
+
+	connections := PipeConnections(me, []*Process{me, peer}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "sort", Pid: 5678}, Protocol: ProtocolPipe, Direction: DirectionUnknown, Count: 1},
+	})
+}
+
+// Several pipes to the same process are several pipes, and get a count rather
+// than a line each.
+func TestPipeConnections_severalPipesToOnePeer(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "grep"}
+	peer := &Process{Pid: 5678, Cmdline: "sort"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {
+			{Fd: "1", Access: PipeAccessWrite, Inode: "16466"},
+			{Fd: "4", Access: PipeAccessWrite, Inode: "16467"},
+		},
+		5678: {
+			{Fd: "0", Access: PipeAccessRead, Inode: "16466"},
+			{Fd: "3", Access: PipeAccessRead, Inode: "16467"},
+		},
+	}
+
+	connections := PipeConnections(me, []*Process{me, peer}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "sort", Pid: 5678}, Protocol: ProtocolPipe, Direction: DirectionOutgoing, Count: 2},
+	})
+}
+
+// A pipe has as many ends as anybody cares to fork, unlike a socket, which has
+// exactly two. Everybody holding a reading end of ours can read what we write,
+// so they all get a line.
+func TestPipeConnections_severalReaders(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "grep"}
+	parent := &Process{Pid: 5678, Cmdline: "sort"}
+	child := &Process{Pid: 5679, Cmdline: "sort"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {{Fd: "1", Access: PipeAccessWrite, Inode: "16466"}},
+		5678: {{Fd: "0", Access: PipeAccessRead, Inode: "16466"}},
+		5679: {{Fd: "0", Access: PipeAccessRead, Inode: "16466"}},
+	}
+
+	connections := PipeConnections(me, []*Process{me, parent, child}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "sort", Pid: 5678}, Protocol: ProtocolPipe, Direction: DirectionOutgoing, Count: 1},
+		{Peer: Peer{Name: "sort", Pid: 5679}, Protocol: ProtocolPipe, Direction: DirectionOutgoing, Count: 1},
+	})
+}
+
+// The reader's view of the pipe two processes write into: two writers, so two
+// lines, one per process it can receive from.
+func TestPipeConnections_severalWriters(t *testing.T) {
+	writer := &Process{Pid: 1234, Cmdline: "grep"}
+	fellowWriter := &Process{Pid: 1235, Cmdline: "sed"}
+	me := &Process{Pid: 5678, Cmdline: "sort"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {{Fd: "1", Access: PipeAccessWrite, Inode: "16466"}},
+		1235: {{Fd: "1", Access: PipeAccessWrite, Inode: "16466"}},
+		5678: {{Fd: "0", Access: PipeAccessRead, Inode: "16466"}},
+	}
+
+	connections := PipeConnections(me, []*Process{writer, fellowWriter, me}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "grep", Pid: 1234}, Protocol: ProtocolPipe, Direction: DirectionIncoming, Count: 1},
+		{Peer: Peer{Name: "sed", Pid: 1235}, Protocol: ProtocolPipe, Direction: DirectionIncoming, Count: 1},
+	})
+}
+
+// An end opened for reading and writing both, which is what "exec 3<>fifo"
+// gets you, can send to a reader as well as any writer can.
+//
+// Which way the data goes it can't say, so the arrow points both ways.
+func TestPipeConnections_readWriteEndPairsWithAReader(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "shell"}
+	peer := &Process{Pid: 5678, Cmdline: "consumer"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {{Fd: "3", Access: PipeAccessReadWrite, Inode: "82144503"}},
+		5678: {{Fd: "0", Access: PipeAccessRead, Inode: "82144503"}},
+	}
+
+	connections := PipeConnections(me, []*Process{me, peer}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "consumer", Pid: 5678}, Protocol: ProtocolPipe, Direction: DirectionUnknown, Count: 1},
+	})
+}
+
+// Two processes with a FIFO open for reading and writing both can each send to
+// the other, so they are peers however identical their access modes are. This is
+// the one case where two ends spelled the same way do make a pair.
+func TestPipeConnections_twoReadWriteEndsArePeers(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "shell"}
+	peer := &Process{Pid: 5678, Cmdline: "othershell"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {{Fd: "3", Access: PipeAccessReadWrite, Inode: "82144503"}},
+		5678: {{Fd: "3", Access: PipeAccessReadWrite, Inode: "82144503"}},
+	}
+
+	connections := PipeConnections(me, []*Process{me, peer}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "othershell", Pid: 5678}, Protocol: ProtocolPipe, Direction: DirectionUnknown, Count: 1},
+	})
+}
+
+// A pipe whose other end we can't see tells us nothing: it may be held by a
+// process we aren't allowed to inspect, or by nobody at all, and there is no
+// telling those apart.
+func TestPipeConnections_peerNotFound(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "grep"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {
+			{Fd: "1", Access: PipeAccessWrite, Inode: "16466"},
+			{Fd: "4", Device: "0xaaaa", PeerDevice: "0xbbbb"},
+			// The way lsof reports a pipe with nobody at the other end
+			{Fd: "5", Device: "0xcccc"},
+		},
+	}
+
+	connections := PipeConnections(me, []*Process{me}, pipeEnds)
+
+	assert.Equal(t, len(connections), 0)
+}
+
+// A process holding both ends of a pipe holds one pipe, and one pipe is one
+// line. The writing end is the one it gets reported by, data flowing from there.
+func TestPipeConnections_selfPipeWithAccessModes(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "grep"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {
+			{Fd: "3", Access: PipeAccessRead, Inode: "16466"},
+			{Fd: "4", Access: PipeAccessWrite, Inode: "16466"},
+		},
+	}
+
+	connections := PipeConnections(me, []*Process{me}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "grep", Pid: 1234}, Protocol: ProtocolPipe, Direction: DirectionOutgoing, Count: 1},
+	})
+}
+
+// The same pipe on macOS, where lsof won't say which end writes. Still one pipe
+// and still one line, reported by whichever end this picks as long as it picks
+// the same one every time.
+func TestPipeConnections_selfPipeWithoutAccessModes(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "grep"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {
+			{Fd: "3", Device: "0xaaaa", PeerDevice: "0xbbbb"},
+			{Fd: "4", Device: "0xbbbb", PeerDevice: "0xaaaa"},
+		},
+	}
+
+	connections := PipeConnections(me, []*Process{me}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "grep", Pid: 1234}, Protocol: ProtocolPipe, Direction: DirectionUnknown, Count: 1},
+	})
+}
+
+// lsof runs after the process listing, so a peer can be a process we have no
+// name for. Its PID is still worth reporting.
+func TestPipeConnections_namelessPeer(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "grep"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {{Fd: "1", Access: PipeAccessWrite, Inode: "16466"}},
+		5678: {{Fd: "0", Access: PipeAccessRead, Inode: "16466"}},
+	}
+
+	connections := PipeConnections(me, []*Process{me}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Pid: 5678}, Protocol: ProtocolPipe, Direction: DirectionOutgoing, Count: 1},
+	})
+}
+
+// A process we hold no pipe ends of, because it has none or because we aren't
+// allowed to inspect it.
+func TestPipeConnections_noPipesAtAll(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "grep"}
+
+	connections := PipeConnections(me, []*Process{me}, map[int][]PipeEnd{})
+
+	assert.Equal(t, len(connections), 0)
+}
+
+// A pipe we made ourselves, matched against itself through the real lsof. Both
+// of its ends are ours, so this is the self-pipe case, and it is what says that
+// the matching works on whatever platform and lsof version this is.
+func TestPipeConnections_realPipe(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not available: ", err)
+	}
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	}()
+
+	pipeEndsByPid, err := GetPipeEndsByPid()
+	if err != nil {
+		t.Fatalf("listing pipes failed: %v", err)
+	}
+
+	me := &Process{Pid: os.Getpid(), Cmdline: "pipes.test"}
+
+	foundOurselves := false
+	for _, connection := range PipeConnections(me, []*Process{me}, pipeEndsByPid) {
+		if connection.Peer.Pid != me.Pid {
+			// The pipes the test runner talks to us over
+			continue
+		}
+
+		// No assertion on the count: it aggregates distinct pipes to the same
+		// peer, and anything else in this binary holding both ends of a pipe of
+		// its own would add to it. What the count has to get right is covered by
+		// the tests above, on data we control.
+		assert.Equal(t, connection.Protocol, ProtocolPipe)
+
+		foundOurselves = true
+	}
+
+	assert.Equal(t, foundOurselves, true)
+}

--- a/internal/processes/pipeconnections_test.go
+++ b/internal/processes/pipeconnections_test.go
@@ -177,6 +177,111 @@ func TestPipeConnections_severalPipesToOnePeer(t *testing.T) {
 	})
 }
 
+// Two named FIFOs on different file systems can share an inode number, and then
+// their ends are not each other's however equal those numbers are. Nothing was
+// written into one that can be read out of the other.
+//
+// Captured on Linux: two tmpfs mounts, one FIFO on each, both the first file on
+// their file system and so both inode 2, told apart by their devices alone.
+func TestPipeConnections_sameInodeOnAnotherFileSystemIsNoPeer(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "producer"}
+	stranger := &Process{Pid: 5678, Cmdline: "consumer"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {{Fd: "3", Access: PipeAccessWrite, FileSystemDevice: "0x37", Inode: "2"}},
+		5678: {{Fd: "3", Access: PipeAccessRead, FileSystemDevice: "0x38", Inode: "2"}},
+	}
+
+	connections := PipeConnections(me, []*Process{me, stranger}, pipeEnds)
+
+	assert.Equal(t, len(connections), 0)
+}
+
+// Two FIFOs that happen to share an inode number are two pipes, so a peer at the
+// end of both has two of them with us and earns a count of 2.
+//
+// The same pair of tmpfs FIFOs as above, this time with both processes holding an
+// end of each.
+func TestPipeConnections_twoFifosSharingAnInodeAreTwoPipes(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "producer"}
+	peer := &Process{Pid: 5678, Cmdline: "consumer"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {
+			{Fd: "3", Access: PipeAccessWrite, FileSystemDevice: "0x37", Inode: "2"},
+			{Fd: "4", Access: PipeAccessWrite, FileSystemDevice: "0x38", Inode: "2"},
+		},
+		5678: {
+			{Fd: "3", Access: PipeAccessRead, FileSystemDevice: "0x37", Inode: "2"},
+			{Fd: "4", Access: PipeAccessRead, FileSystemDevice: "0x38", Inode: "2"},
+		},
+	}
+
+	connections := PipeConnections(me, []*Process{me, peer}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "consumer", Pid: 5678}, Protocol: ProtocolPipe, Direction: DirectionOutgoing, Count: 2},
+	})
+}
+
+// One pipe is one line however many ends of it we hold ourselves, and the ends we
+// hold can disagree about which way the data goes: "exec 3>fifo 4<>fifo" gets us
+// a write end, which says outgoing, and a read-write end, which can't say.
+//
+// So the line goes by what our ends together let us do with the pipe, which here
+// is both reading and writing, and that gets no arrow. Two lines to the one peer
+// would claim two pipes where there is one.
+//
+// The second line is ourselves, and it is not a duplicate: we can write on fd 3
+// and read it back on fd 4, so we are one of the processes at the other end of
+// this FIFO, the same way any process holding both ends of a pipe is.
+func TestPipeConnections_writeAndReadWriteEndsOfOnePipe(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "shell"}
+	peer := &Process{Pid: 5678, Cmdline: "consumer"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {
+			{Fd: "3", Access: PipeAccessWrite, FileSystemDevice: "0x37", Inode: "2"},
+			{Fd: "4", Access: PipeAccessReadWrite, FileSystemDevice: "0x37", Inode: "2"},
+		},
+		5678: {{Fd: "3", Access: PipeAccessRead, FileSystemDevice: "0x37", Inode: "2"}},
+	}
+
+	connections := PipeConnections(me, []*Process{me, peer}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "consumer", Pid: 5678}, Protocol: ProtocolPipe, Direction: DirectionUnknown, Count: 1},
+		{Peer: Peer{Name: "shell", Pid: 1234}, Protocol: ProtocolPipe, Direction: DirectionUnknown, Count: 1},
+	})
+}
+
+// Two pipes to one peer, one each way, which is what a process in the middle of a
+// pipeline has with the process before it if that one reads its answers back.
+// Different pipes and different directions, so two lines rather than one line
+// counting two.
+func TestPipeConnections_onePipeEachWayToOnePeer(t *testing.T) {
+	me := &Process{Pid: 1234, Cmdline: "grep"}
+	peer := &Process{Pid: 5678, Cmdline: "sort"}
+
+	pipeEnds := map[int][]PipeEnd{
+		1234: {
+			{Fd: "3", Access: PipeAccessWrite, FileSystemDevice: "0xe", Inode: "16466"},
+			{Fd: "4", Access: PipeAccessRead, FileSystemDevice: "0xe", Inode: "16467"},
+		},
+		5678: {
+			{Fd: "0", Access: PipeAccessRead, FileSystemDevice: "0xe", Inode: "16466"},
+			{Fd: "1", Access: PipeAccessWrite, FileSystemDevice: "0xe", Inode: "16467"},
+		},
+	}
+
+	connections := PipeConnections(me, []*Process{me, peer}, pipeEnds)
+
+	assert.SlicesEqual(t, connections, []Connection{
+		{Peer: Peer{Name: "sort", Pid: 5678}, Protocol: ProtocolPipe, Direction: DirectionIncoming, Count: 1},
+		{Peer: Peer{Name: "sort", Pid: 5678}, Protocol: ProtocolPipe, Direction: DirectionOutgoing, Count: 1},
+	})
+}
+
 // A pipe has as many ends as anybody cares to fork, unlike a socket, which has
 // exactly two. Everybody holding a reading end of ours can read what we write,
 // so they all get a line.

--- a/internal/processes/pipes.go
+++ b/internal/processes/pipes.go
@@ -50,6 +50,16 @@ type PipeEnd struct {
 	// macOS for an anonymous pipe, and populated on both platforms for a named
 	// FIFO.
 	Inode string
+
+	// The number of the file system the pipe lives on, which is what tells two
+	// pipes sharing an inode number apart. Hex, "0x37", and opaque: it is
+	// compared and never counted with.
+	//
+	// Linux reports it for every pipe, an anonymous one living on pipefs and so
+	// sharing it with every other anonymous pipe on the machine. macOS reports it
+	// for no pipe at all, neither anonymous nor named, so there two pipes are
+	// told apart by their inodes and their kernel addresses alone.
+	FileSystemDevice string
 }
 
 // Maps PIDs to the pipe ends held open by the corresponding processes, named

--- a/internal/processes/pipes.go
+++ b/internal/processes/pipes.go
@@ -1,6 +1,10 @@
 package processes
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/walles/ftop/internal/log"
 	"github.com/walles/ftop/internal/util"
 )
@@ -91,7 +95,15 @@ func GetPipeEndsByPid() (map[int][]PipeEnd, error) {
 	return parser.pipeEndsByPid, nil
 }
 
-// Parses the output of "lsof -n -w -F pfatdin0".
+// Parses the output of "lsof -n -w -F pfatdin0", which comes in NUL terminated
+// fields, one line per process and then one line per open file:
+//
+//	p36143\0
+//	f1\0a \0tPIPE\0d0x77046c8deffe9dd1\0n->0x652aa8d44c539286\0
+//	f4\0ar\0tFIFO\0i82144503\0n/private/tmp/probe.fifo\0
+//
+// This listing is unfiltered, lsof having no flag for selecting pipes, so most
+// of what arrives here is files of other kinds and gets dropped.
 type lsofPipeParser struct {
 	pipeEndsByPid map[int][]PipeEnd
 
@@ -106,7 +118,107 @@ func newLsofPipeParser() lsofPipeParser {
 	}
 }
 
+// Note that lsof escapes non-printable characters, newlines included, so one
+// line of output is always one complete record.
 func (parser *lsofPipeParser) parseLine(line string) error {
-	// TODO: Implement
+	// Filled in by the fields of this line, whatever kind of file it describes
+	var record lsofFileRecord
+
+	for field := range strings.SplitSeq(strings.TrimSuffix(line, "\x00"), "\x00") {
+		err := parser.parseField(field, &record)
+		if err != nil {
+			return err
+		}
+	}
+
+	if record.fileType != "PIPE" && record.fileType != "FIFO" {
+		// A line naming a process, or a file of some other kind, which is most
+		// of them in an unfiltered listing. macOS names a unix domain socket
+		// exactly the way it names a pipe, so the type is what keeps those two
+		// apart.
+		return nil
+	}
+
+	if parser.pid == -1 {
+		return fmt.Errorf("lsof reported pipe on fd <%s> before any PID", record.end.Fd)
+	}
+
+	parser.pipeEndsByPid[parser.pid] = append(parser.pipeEndsByPid[parser.pid], record.end)
+
 	return nil
+}
+
+// One lsof record being decoded field by field, whether or not it turns out to
+// describe a pipe.
+type lsofFileRecord struct {
+	end PipeEnd
+
+	// lsof's type column: "PIPE", "FIFO", "REG", "IPv4" and so on
+	fileType string
+}
+
+// Applies one field to record, or to the parser itself for the PID field.
+func (parser *lsofPipeParser) parseField(field string, record *lsofFileRecord) error {
+	if field == "" {
+		return nil
+	}
+
+	identifier := field[0]
+	value := field[1:]
+
+	switch identifier {
+	case 'p':
+		pid, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("unparseable lsof PID <%s>: %w", value, err)
+		}
+
+		parser.pid = pid
+
+	case 'f':
+		record.end.Fd = value
+
+	case 'a':
+		record.end.Access = parsePipeAccess(value)
+
+	case 't':
+		record.fileType = value
+
+	case 'd':
+		record.end.Device = value
+
+	case 'i':
+		record.end.Inode = value
+
+	case 'n':
+		// macOS names an anonymous pipe end by its peer's kernel address, and
+		// that is the one name here that identifies anything. Linux calls every
+		// anonymous pipe "pipe", a named FIFO is named by its path, and neither
+		// one says who is at the other end.
+		peerDevice, namesAPeer := strings.CutPrefix(value, "->")
+		if namesAPeer {
+			record.end.PeerDevice = peerDevice
+		}
+	}
+
+	// lsof can emit fields we didn't ask for, just ignore those
+	return nil
+}
+
+// lsof's access mode column, which is a space wherever lsof has nothing to say
+// and is that for every anonymous pipe on macOS.
+func parsePipeAccess(value string) PipeAccess {
+	switch value {
+	case "r":
+		return PipeAccessRead
+
+	case "w":
+		return PipeAccessWrite
+
+	case "u":
+		return PipeAccessReadWrite
+
+	default:
+		return PipeAccessUnknown
+	}
 }

--- a/internal/processes/pipes.go
+++ b/internal/processes/pipes.go
@@ -78,13 +78,17 @@ func GetPipeEndsByPid() (map[int][]PipeEnd, error) {
 	// -n: Don't resolve host names, they are slow and the network sockets this
 	//   unfiltered listing drags along would otherwise be looked up one by one
 	// -w: Don't warn about processes we aren't allowed to inspect
-	// -F pfatdin0: Machine readable output with NUL terminated PID, file
-	//   descriptor, access mode, type, device, inode and name fields
+	// -F pfatdDin0: Machine readable output with NUL terminated PID, file
+	//   descriptor, access mode, type, device, file system device, inode and name
+	//   fields. The two device fields are different things and we want both: "d"
+	//   is lsof's device character code, which on macOS is a pipe end's kernel
+	//   address, while "D" is the device number of the file system the file lives
+	//   on, which is what tells two FIFOs sharing an inode number apart.
 	//
 	// No filter flag, lsof having none for pipes, so this lists every open file
 	// of every process. See GetSocketsByPid() for the cheaper filtered listing
 	// the socket sections use.
-	commandline := []string{"lsof", "-n", "-w", "-F", "pfatdin0"}
+	commandline := []string{"lsof", "-n", "-w", "-F", "pfatdDin0"}
 
 	// Locale intentionally left alone, matching GetCwdsByPid()
 	err := util.ExecInUsersLocale(commandline, parser.parseLine)
@@ -105,12 +109,16 @@ func GetPipeEndsByPid() (map[int][]PipeEnd, error) {
 	return parser.pipeEndsByPid, nil
 }
 
-// Parses the output of "lsof -n -w -F pfatdin0", which comes in NUL terminated
+// Parses the output of "lsof -n -w -F pfatdDin0", which comes in NUL terminated
 // fields, one line per process and then one line per open file:
 //
 //	p36143\0
 //	f1\0a \0tPIPE\0d0x77046c8deffe9dd1\0n->0x652aa8d44c539286\0
 //	f4\0ar\0tFIFO\0i82144503\0n/private/tmp/probe.fifo\0
+//	f3\0au\0tFIFO\0D0x37\0i2\0n/mnt/a/f\0
+//
+// The first two lines are macOS, the third Linux, which is the only platform to
+// report a "D" field for a pipe at all.
 //
 // This listing is unfiltered, lsof having no flag for selecting pipes, so most
 // of what arrives here is files of other kinds and gets dropped.
@@ -196,6 +204,9 @@ func (parser *lsofPipeParser) parseField(field string, record *lsofFileRecord) e
 
 	case 'd':
 		record.end.Device = value
+
+	case 'D':
+		record.end.FileSystemDevice = value
 
 	case 'i':
 		record.end.Inode = value

--- a/internal/processes/pipes.go
+++ b/internal/processes/pipes.go
@@ -1,0 +1,112 @@
+package processes
+
+import (
+	"github.com/walles/ftop/internal/log"
+	"github.com/walles/ftop/internal/util"
+)
+
+// How a pipe end is open, as lsof spells it.
+//
+// Empty when lsof won't say, which is every anonymous pipe on macOS.
+type PipeAccess string
+
+const (
+	PipeAccessRead      PipeAccess = "r"
+	PipeAccessWrite     PipeAccess = "w"
+	PipeAccessReadWrite PipeAccess = "u"
+	PipeAccessUnknown   PipeAccess = ""
+)
+
+// One end of a pipe held open by some process, as reported by lsof.
+//
+// Which fields are populated is a platform difference, and the two ways of
+// matching a pair of ends are built on exactly that, see arePipeEnds().
+type PipeEnd struct {
+	// lsof's file descriptor number, "1" or similar. Not an identity: one end is
+	// reported once per descriptor it is open on. See deduplicatePipeEnds() for
+	// what does identify one.
+	Fd string
+
+	Access PipeAccess
+
+	// lsof's device column, an opaque string rather than a number because the
+	// platforms don't agree on what kind of number it is: macOS gives the kernel
+	// address of this very end, "0x77046c8deffe9dd1", while Linux gives the
+	// major and minor numbers of the file system a FIFO lives on. Empty wherever
+	// lsof reports no device at all, which is macOS for a named FIFO.
+	Device string
+
+	// The Device of the end at the other side of this pipe, which is how macOS
+	// names an anonymous pipe end. Empty for a pipe lsof doesn't name that way,
+	// every Linux one included, and empty on macOS once the other end is gone.
+	PeerDevice string
+
+	// The pipe's inode number, the same for both of its ends. A string for the
+	// same reason Device is one: it is compared and never counted with. Empty on
+	// macOS for an anonymous pipe, and populated on both platforms for a named
+	// FIFO.
+	Inode string
+}
+
+// Maps PIDs to the pipe ends held open by the corresponding processes, named
+// FIFOs included.
+//
+// The listing is partial: processes we aren't allowed to inspect are missing
+// from the map, so expect only a fraction of the running processes when not
+// running as root. Processes without any pipes are missing as well.
+//
+// This forks lsof without a filter, since lsof has no flag for selecting pipes,
+// so it costs about twice what the filtered socket listing does. Too slow for
+// calling once per frame, fine for on-demand lookups.
+func GetPipeEndsByPid() (map[int][]PipeEnd, error) {
+	parser := newLsofPipeParser()
+
+	// -n: Don't resolve host names, they are slow and the network sockets this
+	//   unfiltered listing drags along would otherwise be looked up one by one
+	// -w: Don't warn about processes we aren't allowed to inspect
+	// -F pfatdin0: Machine readable output with NUL terminated PID, file
+	//   descriptor, access mode, type, device, inode and name fields
+	//
+	// No filter flag, lsof having none for pipes, so this lists every open file
+	// of every process. See GetSocketsByPid() for the cheaper filtered listing
+	// the socket sections use.
+	commandline := []string{"lsof", "-n", "-w", "-F", "pfatdin0"}
+
+	// Locale intentionally left alone, matching GetCwdsByPid()
+	err := util.ExecInUsersLocale(commandline, parser.parseLine)
+	if err == nil {
+		return parser.pipeEndsByPid, nil
+	}
+
+	// lsof exits non-zero as soon as anything at all went wrong, and failing to
+	// inspect some process is business as usual. Whatever it did manage to
+	// report is still good, so only give up if we got nothing.
+	if len(parser.pipeEndsByPid) == 0 {
+		return nil, err
+	}
+
+	log.Infof("Listing pipes partially failed, got %d processes' worth: %v",
+		len(parser.pipeEndsByPid), err)
+
+	return parser.pipeEndsByPid, nil
+}
+
+// Parses the output of "lsof -n -w -F pfatdin0".
+type lsofPipeParser struct {
+	pipeEndsByPid map[int][]PipeEnd
+
+	// PID from the most recent "p" field, or -1 before the first one
+	pid int
+}
+
+func newLsofPipeParser() lsofPipeParser {
+	return lsofPipeParser{
+		pipeEndsByPid: map[int][]PipeEnd{},
+		pid:           -1,
+	}
+}
+
+func (parser *lsofPipeParser) parseLine(line string) error {
+	// TODO: Implement
+	return nil
+}

--- a/internal/processes/pipes.go
+++ b/internal/processes/pipes.go
@@ -33,11 +33,14 @@ type PipeEnd struct {
 
 	Access PipeAccess
 
-	// lsof's device column, an opaque string rather than a number because the
-	// platforms don't agree on what kind of number it is: macOS gives the kernel
-	// address of this very end, "0x77046c8deffe9dd1", while Linux gives the
-	// major and minor numbers of the file system a FIFO lives on. Empty wherever
-	// lsof reports no device at all, which is macOS for a named FIFO.
+	// lsof's lowercase "d" column, the kernel address of this very end,
+	// "0x77046c8deffe9dd1". A string rather than a number because it is compared
+	// and never counted with.
+	//
+	// Populated for a macOS anonymous pipe and for nothing else: every FIFO record
+	// has it empty, on both platforms, so a set Device amounts to a statement that
+	// macOS reported this end. The file system device Linux reports for a pipe is a
+	// different field, see FileSystemDevice.
 	Device string
 
 	// The Device of the end at the other side of this pipe, which is how macOS

--- a/internal/processes/pipes_test.go
+++ b/internal/processes/pipes_test.go
@@ -3,7 +3,9 @@ package processes
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
+	"syscall"
 	"testing"
 
 	"github.com/walles/ftop/internal/assert"
@@ -37,24 +39,53 @@ func TestLsofPipeParser_macOsPipePair(t *testing.T) {
 // How Linux names the two ends of an anonymous pipe: both by the pipe's inode,
 // with the access modes telling them apart. The name is the literal string
 // "pipe", which identifies nothing and is dropped.
+//
+// Every anonymous pipe on the machine lives on pipefs and so reports the same
+// file system device, 0xe here, which is why the inode is what tells two of them
+// apart. The device only starts saying something for a named FIFO.
 func TestLsofPipeParser_linuxPipePair(t *testing.T) {
 	parser := newLsofPipeParser()
 
 	lines := []string{
 		"p1234\x00",
-		"f1\x00aw\x00tFIFO\x00i16466\x00npipe\x00",
+		"f1\x00aw\x00tFIFO\x00D0xe\x00i16466\x00npipe\x00",
 		"p5678\x00",
-		"f0\x00ar\x00tFIFO\x00i16466\x00npipe\x00",
+		"f0\x00ar\x00tFIFO\x00D0xe\x00i16466\x00npipe\x00",
 	}
 	for _, line := range lines {
 		assert.Equal(t, parser.parseLine(line), nil)
 	}
 
 	assert.SlicesEqual(t, parser.pipeEndsByPid[1234], []PipeEnd{
-		{Fd: "1", Access: PipeAccessWrite, Inode: "16466"},
+		{Fd: "1", Access: PipeAccessWrite, FileSystemDevice: "0xe", Inode: "16466"},
 	})
 	assert.SlicesEqual(t, parser.pipeEndsByPid[5678], []PipeEnd{
-		{Fd: "0", Access: PipeAccessRead, Inode: "16466"},
+		{Fd: "0", Access: PipeAccessRead, FileSystemDevice: "0xe", Inode: "16466"},
+	})
+}
+
+// Two named FIFOs on different file systems can share an inode number, and then
+// the file system device is the only thing telling them apart. Both of these are
+// inode 2, each being the first file made on a freshly mounted tmpfs.
+//
+// lsof hands that device over under the "D" field descriptor and only under that
+// one: the lowercase "d" that carries a macOS pipe's kernel address is empty for
+// every FIFO, on both platforms.
+func TestLsofPipeParser_linuxNamedFifosSharingAnInode(t *testing.T) {
+	parser := newLsofPipeParser()
+
+	lines := []string{
+		"p188\x00",
+		"f3\x00au\x00tFIFO\x00D0x37\x00i2\x00n/mnt/a/f\x00",
+		"f4\x00au\x00tFIFO\x00D0x38\x00i2\x00n/mnt/b/f\x00",
+	}
+	for _, line := range lines {
+		assert.Equal(t, parser.parseLine(line), nil)
+	}
+
+	assert.SlicesEqual(t, parser.pipeEndsByPid[188], []PipeEnd{
+		{Fd: "3", Access: PipeAccessReadWrite, FileSystemDevice: "0x37", Inode: "2"},
+		{Fd: "4", Access: PipeAccessReadWrite, FileSystemDevice: "0x38", Inode: "2"},
 	})
 }
 
@@ -196,4 +227,71 @@ func TestGetPipeEndsByPid(t *testing.T) {
 
 	assert.Equal(t, foundReader, true)
 	assert.Equal(t, foundWriter, true)
+}
+
+// The real lsof should tell us enough about the two ends of a named FIFO for
+// arePipeEnds() to match them, on whatever platform and lsof version this is.
+//
+// A FIFO is the one pipe both platforms report an inode for, and the one Linux
+// reports a file system device for, so the two matching clauses meet here: the
+// inode has to be there, and whatever device comes along with it must not keep
+// two ends of one and the same FIFO apart.
+func TestGetPipeEndsByPid_namedFifo(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not available: ", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "probe.fifo")
+	err := syscall.Mkfifo(path, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read-write first: opening a FIFO that way never blocks, and it makes the
+	// reader below a reader of a FIFO somebody already has open for writing,
+	// which doesn't block either.
+	readWrite, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = readWrite.Close() }()
+
+	read, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = read.Close() }()
+
+	readWriteFd := strconv.Itoa(int(readWrite.Fd()))
+	readFd := strconv.Itoa(int(read.Fd()))
+
+	pipeEndsByPid, err := GetPipeEndsByPid()
+	if err != nil {
+		t.Fatalf("listing pipes failed: %v", err)
+	}
+
+	var readWriteEnd *PipeEnd
+	var readEnd *PipeEnd
+	for _, end := range pipeEndsByPid[os.Getpid()] {
+		switch end.Fd {
+		case readWriteFd:
+			readWriteEnd = &end
+
+		case readFd:
+			readEnd = &end
+		}
+	}
+
+	if readWriteEnd == nil || readEnd == nil {
+		t.Fatalf("lsof reported %v, missing fd %s or %s",
+			pipeEndsByPid[os.Getpid()], readWriteFd, readFd)
+	}
+
+	// The inode is what identifies a FIFO on both platforms, and lsof reporting
+	// the access modes is what tells its ends apart.
+	assert.Equal(t, readWriteEnd.Inode != "", true)
+	assert.Equal(t, readWriteEnd.Access, PipeAccessReadWrite)
+	assert.Equal(t, readEnd.Access, PipeAccessRead)
+
+	assert.Equal(t, arePipeEnds(*readWriteEnd, *readEnd), true)
 }

--- a/internal/processes/pipes_test.go
+++ b/internal/processes/pipes_test.go
@@ -1,0 +1,199 @@
+package processes
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+
+	"github.com/walles/ftop/internal/assert"
+)
+
+// How macOS names the two ends of an anonymous pipe: each end by its own kernel
+// address in the device field, and by its peer's in the name. No inode, and no
+// access mode either, macOS lsof having nothing to say about which end writes.
+func TestLsofPipeParser_macOsPipePair(t *testing.T) {
+	parser := newLsofPipeParser()
+
+	lines := []string{
+		"p36143\x00",
+		"f1\x00a \x00tPIPE\x00d0x77046c8deffe9dd1\x00n->0x652aa8d44c539286\x00",
+		"p36144\x00",
+		"f0\x00a \x00tPIPE\x00d0x652aa8d44c539286\x00n->0x77046c8deffe9dd1\x00",
+	}
+	for _, line := range lines {
+		assert.Equal(t, parser.parseLine(line), nil)
+	}
+
+	assert.Equal(t, len(parser.pipeEndsByPid), 2)
+	assert.SlicesEqual(t, parser.pipeEndsByPid[36143], []PipeEnd{
+		{Fd: "1", Device: "0x77046c8deffe9dd1", PeerDevice: "0x652aa8d44c539286"},
+	})
+	assert.SlicesEqual(t, parser.pipeEndsByPid[36144], []PipeEnd{
+		{Fd: "0", Device: "0x652aa8d44c539286", PeerDevice: "0x77046c8deffe9dd1"},
+	})
+}
+
+// How Linux names the two ends of an anonymous pipe: both by the pipe's inode,
+// with the access modes telling them apart. The name is the literal string
+// "pipe", which identifies nothing and is dropped.
+func TestLsofPipeParser_linuxPipePair(t *testing.T) {
+	parser := newLsofPipeParser()
+
+	lines := []string{
+		"p1234\x00",
+		"f1\x00aw\x00tFIFO\x00i16466\x00npipe\x00",
+		"p5678\x00",
+		"f0\x00ar\x00tFIFO\x00i16466\x00npipe\x00",
+	}
+	for _, line := range lines {
+		assert.Equal(t, parser.parseLine(line), nil)
+	}
+
+	assert.SlicesEqual(t, parser.pipeEndsByPid[1234], []PipeEnd{
+		{Fd: "1", Access: PipeAccessWrite, Inode: "16466"},
+	})
+	assert.SlicesEqual(t, parser.pipeEndsByPid[5678], []PipeEnd{
+		{Fd: "0", Access: PipeAccessRead, Inode: "16466"},
+	})
+}
+
+// A named FIFO is a FIFO with a path, reported with an inode and an access mode
+// on both platforms. This one is from macOS, which spells anonymous pipes
+// entirely differently, so the two kinds have to both come through.
+//
+// The path is no peer, however much of a name it is, and must not be mistaken
+// for one.
+func TestLsofPipeParser_namedFifo(t *testing.T) {
+	parser := newLsofPipeParser()
+
+	lines := []string{
+		"p36166\x00",
+		"f4\x00ar\x00tFIFO\x00i82144503\x00n/private/tmp/probe.fifo\x00",
+		"f5\x00au\x00tFIFO\x00i82144503\x00n/private/tmp/probe.fifo\x00",
+	}
+	for _, line := range lines {
+		assert.Equal(t, parser.parseLine(line), nil)
+	}
+
+	assert.SlicesEqual(t, parser.pipeEndsByPid[36166], []PipeEnd{
+		{Fd: "4", Access: PipeAccessRead, Inode: "82144503"},
+		{Fd: "5", Access: PipeAccessReadWrite, Inode: "82144503"},
+	})
+}
+
+// Pipes have no filter flag of their own, so this listing arrives mixed in with
+// every other open file on the machine. Everything that isn't a pipe has to go,
+// and must not cost us the pipes around it.
+//
+// The unix domain socket is the one to watch: macOS names those exactly the way
+// it names pipes, so the type is all that keeps them apart.
+func TestLsofPipeParser_ignoresOtherFileTypes(t *testing.T) {
+	parser := newLsofPipeParser()
+
+	lines := []string{
+		"p36143\x00",
+		"fcwd\x00a \x00tDIR\x00i72202814\x00n/private/tmp\x00",
+		"ftxt\x00a \x00tREG\x00i1152921500312522712\x00n/bin/sleep\x00",
+		"f0\x00ar\x00tCHR\x00i314\x00n/dev/null\x00",
+		"f1\x00a \x00tPIPE\x00d0x77046c8deffe9dd1\x00n->0x652aa8d44c539286\x00",
+		"f2\x00au\x00tunix\x00d0x98e949eb4ef84f40\x00n->0x74cc3fffa76a0c30\x00",
+		"f3\x00au\x00tIPv4\x00d0x8df6312a08cb9a23\x00n192.168.50.32:54599->172.217.19.234:443\x00",
+		"f4\x00au\x00tKQUEUE\x00ncount=0, state=0x12\x00",
+	}
+	for _, line := range lines {
+		assert.Equal(t, parser.parseLine(line), nil)
+	}
+
+	assert.SlicesEqual(t, parser.pipeEndsByPid[36143], []PipeEnd{
+		{Fd: "1", Device: "0x77046c8deffe9dd1", PeerDevice: "0x652aa8d44c539286"},
+	})
+}
+
+// lsof reports a pipe whose other end is gone with no name at all. There is
+// nobody to match it against, but it is still a pipe end, and reporting it as
+// one keeps the decision about what to do with it in PipeConnections().
+func TestLsofPipeParser_pipeWithoutAPeer(t *testing.T) {
+	parser := newLsofPipeParser()
+
+	assert.Equal(t, parser.parseLine("p36180\x00"), nil)
+	assert.Equal(t, parser.parseLine("f1\x00a \x00tPIPE\x00d0xc6eabd04a1b56e60\x00n\x00"), nil)
+
+	assert.SlicesEqual(t, parser.pipeEndsByPid[36180], []PipeEnd{
+		{Fd: "1", Device: "0xc6eabd04a1b56e60"},
+	})
+}
+
+// Pipe ends belong to the process lsof most recently named, so one arriving
+// before any process at all is something we can't make sense of.
+func TestLsofPipeParser_pipeBeforeAnyPid(t *testing.T) {
+	parser := newLsofPipeParser()
+
+	err := parser.parseLine("f1\x00a \x00tPIPE\x00d0x77046c8deffe9dd1\x00n->0x652aa8d44c539286\x00")
+
+	assert.Equal(t, err == nil, false)
+}
+
+func TestLsofPipeParser_unparseablePid(t *testing.T) {
+	parser := newLsofPipeParser()
+
+	err := parser.parseLine("pnotanumber\x00")
+
+	assert.Equal(t, err == nil, false)
+}
+
+// The real lsof should see a pipe we just made ourselves, both ends of it, and
+// tell us enough about each end to match the two against each other.
+//
+// The two ways of matching are keyed on the peer's device and on the inode
+// respectively, and this is what says that this platform's lsof reports at least
+// one of them for a pipe. Without that the matching has nothing to work with,
+// however correct it is.
+func TestGetPipeEndsByPid(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not available: ", err)
+	}
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	}()
+
+	readerFd := strconv.Itoa(int(reader.Fd()))
+	writerFd := strconv.Itoa(int(writer.Fd()))
+
+	pipeEndsByPid, err := GetPipeEndsByPid()
+	if err != nil {
+		t.Fatalf("listing pipes failed: %v", err)
+	}
+
+	foundReader := false
+	foundWriter := false
+	for _, end := range pipeEndsByPid[os.Getpid()] {
+		if end.Fd != readerFd && end.Fd != writerFd {
+			// Some other pipe of ours, and those come in shapes this says
+			// nothing about: one whose other end is gone carries neither of the
+			// two fields below.
+			continue
+		}
+
+		// One or the other, never neither: macOS names an anonymous pipe end by
+		// its peer's device and gives it no inode, Linux the other way around.
+		assert.Equal(t, end.PeerDevice != "" || end.Inode != "", true)
+
+		if end.Fd == readerFd {
+			foundReader = true
+		}
+
+		if end.Fd == writerFd {
+			foundWriter = true
+		}
+	}
+
+	assert.Equal(t, foundReader, true)
+	assert.Equal(t, foundWriter, true)
+}

--- a/internal/processes/sockets.go
+++ b/internal/processes/sockets.go
@@ -9,13 +9,15 @@ import (
 	"github.com/walles/ftop/internal/util"
 )
 
-// Which transport protocol a socket speaks, lowercased so that it can go
-// straight into the page.
+// What a connection is carried by, lowercased so that it can go straight into
+// the page. A transport protocol for a socket, and the kind of thing it is for
+// everything else.
 type Protocol string
 
 const (
-	ProtocolTcp Protocol = "tcp"
-	ProtocolUdp Protocol = "udp"
+	ProtocolTcp  Protocol = "tcp"
+	ProtocolUdp  Protocol = "udp"
+	ProtocolPipe Protocol = "pipe"
 )
 
 // One TCP or UDP socket held open by some process, as reported by lsof.

--- a/internal/processes/sockets.go
+++ b/internal/processes/sockets.go
@@ -9,17 +9,6 @@ import (
 	"github.com/walles/ftop/internal/util"
 )
 
-// What a connection is carried by, lowercased so that it can go straight into
-// the page. A transport protocol for a socket, and the kind of thing it is for
-// everything else.
-type Protocol string
-
-const (
-	ProtocolTcp  Protocol = "tcp"
-	ProtocolUdp  Protocol = "udp"
-	ProtocolPipe Protocol = "pipe"
-)
-
 // One TCP or UDP socket held open by some process, as reported by lsof.
 type Socket struct {
 	// lsof's file descriptor number, "31" or similar. Not an identity: one socket


### PR DESCRIPTION
- **IPC pipes: the tests, ahead of the implementation**
- **IPC pipes: the implementation, and an arrow that stops lying**
- **IPC pipes: the Linux tests, and the device lsof was hiding**
- **IPC pipes: the device turned on, and one line per pipe**
- **IPC pipes: say the right thing about the two device fields**
- **IPC design: retire what pipes closed, one kind left**
- **IPC design: prune what the code now documents, move what outlives it**
- **IPC-DESIGN: drop the history git already keeps**
- **IPC: a failed listing belongs among the undetected**
